### PR TITLE
feat: implement MD053 link-image-reference-definitions rule

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,2 +1,1 @@
-Tidy up the code by deleting old, unused code and fixing compiler hints/warnings. Suppress false positive ones, if needed.
-When do general code review, check adherence to the best coding practices on Rust. Also, pay a special attention on potential performance/resource overuse issues.
+Review the code changes in the current branch, ensuring they adhere to the coding standards outlined in CLAUDE.md.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ heading-style = 'err'
 line-length = 'err'
 link-fragments = 'warn'
 reference-links-images = 'err'
+link-image-reference-definitions = 'err'
 
 # see a specific rule's doc for details of configuration
 [linters.settings.heading-style]
@@ -72,11 +73,14 @@ ignored_pattern = ""
 [linters.settings.reference-links-images]
 shortcut_syntax = false
 ignored_labels = ["x"]
+
+[linters.settings.link-image-reference-definitions]
+ignored_definitions = ["//"]
 ```
 
 ## Rules
 
-**Implementation Progress: 5/48 rules completed (10.4%)**
+**Implementation Progress: 6/48 rules completed (12.5%)**
 
 - [x] **[MD001](docs/rules/md001.md)** *heading-increment* - Heading levels should only increment by one level at a time
 - [x] **[MD003](docs/rules/md003.md)** *heading-style* - Consistent heading styles
@@ -125,4 +129,4 @@ ignored_labels = ["x"]
 - [ ] **MD050** *strong-style* - Strong style consistency
 - [x] **[MD051](docs/rules/md051.md)** *link-fragments* - Link fragments should be valid
 - [x] **[MD052](docs/rules/md052.md)** *reference-links-images* - Reference links should be defined
-- [ ] **MD053** *link-image-reference-definitions* - Reference definitions should be needed
+- [x] **[MD053](docs/rules/md053.md)** *link-image-reference-definitions* - Reference definitions should be needed

--- a/crates/quickmark/src/main.rs
+++ b/crates/quickmark/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::Parser;
 use quickmark_config::config_in_path_or_default;
-use quickmark_linter::linter::{MultiRuleLinter, RuleViolation};
 use quickmark_linter::config::{QuickmarkConfig, RuleSeverity};
+use quickmark_linter::linter::{MultiRuleLinter, RuleViolation};
 use std::cmp::min;
 use std::env;
 use std::{fs, path::PathBuf, process::exit};
@@ -73,11 +73,11 @@ fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use quickmark_linter::config::{HeadingStyle, LintersSettingsTable, MD003HeadingStyleTable};
     use quickmark_linter::linter::{CharPosition, Range};
     use quickmark_linter::rules::{md001::MD001, md003::MD003};
     use quickmark_linter::test_utils::test_helpers::test_config_with_settings;
+    use std::path::PathBuf;
 
     #[test]
     fn test_print_cli_errors() {
@@ -94,14 +94,35 @@ mod tests {
             },
         );
         let range = Range {
-            start: CharPosition { line: 1, character: 1 },
-            end: CharPosition { line: 1, character: 5 },
+            start: CharPosition {
+                line: 1,
+                character: 1,
+            },
+            end: CharPosition {
+                line: 1,
+                character: 5,
+            },
         };
         let file = PathBuf::default();
         let results = vec![
-            RuleViolation::new(&MD001, "all is bad".to_string(), file.clone(), range.clone()),
-            RuleViolation::new(&MD003, "all is even worse".to_string(), file.clone(), range.clone()),
-            RuleViolation::new(&MD003, "all is even worse2".to_string(), file.clone(), range),
+            RuleViolation::new(
+                &MD001,
+                "all is bad".to_string(),
+                file.clone(),
+                range.clone(),
+            ),
+            RuleViolation::new(
+                &MD003,
+                "all is even worse".to_string(),
+                file.clone(),
+                range.clone(),
+            ),
+            RuleViolation::new(
+                &MD003,
+                "all is even worse2".to_string(),
+                file.clone(),
+                range,
+            ),
         ];
 
         let (errs, warns) = print_cli_errors(&results, &config);

--- a/crates/quickmark/tests/cli_integration_tests.rs
+++ b/crates/quickmark/tests/cli_integration_tests.rs
@@ -7,8 +7,7 @@ use std::path::PathBuf;
 /// Helper function to get the path to test sample files
 fn test_sample_path(filename: &str) -> String {
     // Use the CARGO_MANIFEST_DIR environment variable to find the project root
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .expect("CARGO_MANIFEST_DIR not set");
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
 
     PathBuf::from(manifest_dir)
         .parent() // Go up from crates/quickmark
@@ -105,7 +104,8 @@ fn test_cli_error_format() {
 
     // Check that error format includes expected components:
     // ERR: file_path:line:column MD001/heading-increment message
-    let error_lines: Vec<&str> = stderr.lines()
+    let error_lines: Vec<&str> = stderr
+        .lines()
         .filter(|line| line.starts_with("ERR:") || line.starts_with("WARN:"))
         .collect();
 
@@ -162,7 +162,8 @@ fn test_cli_line_numbers_are_one_based() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Find error lines and check line numbers
-    let error_lines: Vec<&str> = stderr.lines()
+    let error_lines: Vec<&str> = stderr
+        .lines()
         .filter(|line| line.starts_with("ERR:") || line.starts_with("WARN:"))
         .collect();
 
@@ -174,7 +175,10 @@ fn test_cli_line_numbers_are_one_based() {
                 let line_num_str = &after_file[..second_colon];
                 if let Ok(line_num) = line_num_str.parse::<u32>() {
                     // Line numbers should be 1-based, not 0-based
-                    assert!(line_num >= 1, "Line number should be 1-based, got: {line_num}");
+                    assert!(
+                        line_num >= 1,
+                        "Line number should be 1-based, got: {line_num}"
+                    );
                 }
             }
         }

--- a/crates/quickmark_linter/src/config/mod.rs
+++ b/crates/quickmark_linter/src/config/mod.rs
@@ -80,12 +80,26 @@ impl Default for MD052ReferenceLinksImagesTable {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct MD053LinkImageReferenceDefinitionsTable {
+    pub ignored_definitions: Vec<String>,
+}
+
+impl Default for MD053LinkImageReferenceDefinitionsTable {
+    fn default() -> Self {
+        Self {
+            ignored_definitions: vec!["//".to_string()],
+        }
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct LintersSettingsTable {
     pub heading_style: MD003HeadingStyleTable,
     pub line_length: MD013LineLengthTable,
     pub link_fragments: MD051LinkFragmentsTable,
     pub reference_links_images: MD052ReferenceLinksImagesTable,
+    pub link_image_reference_definitions: MD053LinkImageReferenceDefinitionsTable,
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -126,7 +140,9 @@ mod test {
     use std::collections::HashMap;
 
     use crate::config::{
-        HeadingStyle, LintersSettingsTable, LintersTable, MD003HeadingStyleTable, MD013LineLengthTable, MD051LinkFragmentsTable, MD052ReferenceLinksImagesTable, RuleSeverity,
+        HeadingStyle, LintersSettingsTable, LintersTable, MD003HeadingStyleTable,
+        MD013LineLengthTable, MD051LinkFragmentsTable, MD052ReferenceLinksImagesTable,
+        MD053LinkImageReferenceDefinitionsTable, RuleSeverity,
     };
 
     use super::{normalize_severities, QuickmarkConfig};
@@ -185,6 +201,8 @@ mod test {
                 line_length: MD013LineLengthTable::default(),
                 link_fragments: MD051LinkFragmentsTable::default(),
                 reference_links_images: MD052ReferenceLinksImagesTable::default(),
+                link_image_reference_definitions: MD053LinkImageReferenceDefinitionsTable::default(
+                ),
             },
         });
 

--- a/crates/quickmark_linter/src/lib.rs
+++ b/crates/quickmark_linter/src/lib.rs
@@ -1,26 +1,26 @@
 //! # QuickMark Linter Core
-//! 
+//!
 //! ## Single-Use Architecture Contract
-//! 
+//!
 //! **IMPORTANT**: All linter components in this crate follow a strict single-use contract:
-//! 
+//!
 //! - **Context**: One context instance per document analysis
 //! - **MultiRuleLinter**: One linter instance per document analysis  
 //! - **RuleLinter**: Individual rule linters are used once and discarded
-//! 
+//!
 //! This design eliminates state management complexity.
-//! 
+//!
 //! ### Usage Pattern
 //! ```rust,no_run
 //! use quickmark_linter::linter::MultiRuleLinter;
 //! use quickmark_linter::config::QuickmarkConfig;
 //! use std::path::PathBuf;
-//! 
+//!
 //! // Example usage (variables would be provided by your application)
 //! # let path = PathBuf::new();
 //! # let config: QuickmarkConfig = unimplemented!();
 //! # let source = "";
-//! 
+//!
 //! // Correct: Fresh instances for each document
 //! let mut linter = MultiRuleLinter::new_for_document(path, config, source);
 //! let violations = linter.analyze();

--- a/crates/quickmark_linter/src/rules/md001.rs
+++ b/crates/quickmark_linter/src/rules/md001.rs
@@ -106,7 +106,6 @@ mod test {
         ])
     }
 
-
     #[test]
     fn test_atx_positive() {
         let input = "# Heading level 1

--- a/crates/quickmark_linter/src/rules/md003.rs
+++ b/crates/quickmark_linter/src/rules/md003.rs
@@ -80,7 +80,7 @@ impl MD003Linter {
 
     fn is_atx_closed(&self, node: &Node) -> bool {
         let source = self.context.get_document_content();
-        
+
         // Extract the text content of the heading from the source
         let start_byte = node.start_byte();
         let end_byte = node.end_byte();
@@ -115,7 +115,7 @@ impl RuleLinter for MD003Linter {
                 } else {
                     Some(Style::Atx)
                 }
-            },
+            }
             "setext_heading" => Some(Style::Setext),
             _ => None,
         };
@@ -134,7 +134,7 @@ impl RuleLinter for MD003Linter {
                     } else if style != Style::Atx {
                         self.add_violation(node, "atx", &style);
                     }
-                },
+                }
                 HeadingStyle::SetextWithATXClosed => {
                     // Levels 1-2: must be setext, Levels 3+: must be atx_closed, not plain atx
                     if level <= 2 {
@@ -144,7 +144,7 @@ impl RuleLinter for MD003Linter {
                     } else if style != Style::AtxClosed {
                         self.add_violation(node, "atx_closed", &style);
                     }
-                },
+                }
                 _ => {
                     // For single-style configurations, check against enforced style
                     if let Some(enforced_style) = &self.enforced_style {
@@ -417,10 +417,18 @@ Setext heading 2
         assert_eq!(violations.len(), 4);
 
         // Check specific violation messages
-        assert!(violations[0].message().contains("Expected: setext; Actual: atx"));
-        assert!(violations[1].message().contains("Expected: setext; Actual: atx"));
-        assert!(violations[2].message().contains("Expected: atx; Actual: atx_closed"));
-        assert!(violations[3].message().contains("Expected: atx; Actual: atx_closed"));
+        assert!(violations[0]
+            .message()
+            .contains("Expected: setext; Actual: atx"));
+        assert!(violations[1]
+            .message()
+            .contains("Expected: setext; Actual: atx"));
+        assert!(violations[2]
+            .message()
+            .contains("Expected: atx; Actual: atx_closed"));
+        assert!(violations[3]
+            .message()
+            .contains("Expected: atx; Actual: atx_closed"));
     }
 
     #[test]
@@ -462,10 +470,18 @@ Subtitle
         assert_eq!(violations.len(), 4);
 
         // Check specific violation messages
-        assert!(violations[0].message().contains("Expected: setext; Actual: atx"));
-        assert!(violations[1].message().contains("Expected: setext; Actual: atx"));
-        assert!(violations[2].message().contains("Expected: atx_closed; Actual: atx"));
-        assert!(violations[3].message().contains("Expected: atx_closed; Actual: atx"));
+        assert!(violations[0]
+            .message()
+            .contains("Expected: setext; Actual: atx"));
+        assert!(violations[1]
+            .message()
+            .contains("Expected: setext; Actual: atx"));
+        assert!(violations[2]
+            .message()
+            .contains("Expected: atx_closed; Actual: atx"));
+        assert!(violations[3]
+            .message()
+            .contains("Expected: atx_closed; Actual: atx"));
     }
 
     #[test]
@@ -508,7 +524,9 @@ Subtitle
         assert_eq!(violations.len(), 3);
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: atx_closed; Actual: atx"));
+            assert!(violation
+                .message()
+                .contains("Expected: atx_closed; Actual: atx"));
         }
     }
 
@@ -529,8 +547,12 @@ Setext heading
         // Expect 2 violations: closed ATX and setext (both different from first open ATX)
         assert_eq!(violations.len(), 2);
 
-        assert!(violations[0].message().contains("Expected: atx; Actual: atx_closed"));
-        assert!(violations[1].message().contains("Expected: atx; Actual: setext"));
+        assert!(violations[0]
+            .message()
+            .contains("Expected: atx; Actual: atx_closed"));
+        assert!(violations[1]
+            .message()
+            .contains("Expected: atx; Actual: setext"));
     }
 
     #[test]
@@ -549,7 +571,9 @@ Final setext heading
         assert_eq!(violations.len(), 2); // Only ATX headings violate setext rule
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: setext; Actual: atx"));
+            assert!(violation
+                .message()
+                .contains("Expected: setext; Actual: atx"));
         }
     }
 
@@ -610,7 +634,9 @@ Final setext heading
         assert_eq!(violations.len(), 3);
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: atx_closed; Actual: atx"));
+            assert!(violation
+                .message()
+                .contains("Expected: atx_closed; Actual: atx"));
         }
     }
 
@@ -633,7 +659,9 @@ Final setext heading
         assert_eq!(violations.len(), 4);
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: atx; Actual: atx_closed"));
+            assert!(violation
+                .message()
+                .contains("Expected: atx; Actual: atx_closed"));
         }
     }
 
@@ -654,7 +682,9 @@ Final setext heading
         assert_eq!(violations.len(), 2);
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: atx_closed; Actual: atx"));
+            assert!(violation
+                .message()
+                .contains("Expected: atx_closed; Actual: atx"));
         }
     }
 
@@ -678,7 +708,9 @@ Setext Level 2
         assert_eq!(violations.len(), 2);
 
         for violation in &violations {
-            assert!(violation.message().contains("Expected: setext; Actual: atx_closed"));
+            assert!(violation
+                .message()
+                .contains("Expected: setext; Actual: atx_closed"));
         }
     }
 }

--- a/crates/quickmark_linter/src/rules/md013.rs
+++ b/crates/quickmark_linter/src/rules/md013.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// MD013 Line Length Rule Linter
-/// 
+///
 /// **SINGLE-USE CONTRACT**: This linter is designed for one-time use only.
 /// After processing a document (via feed() calls and finalize()), the linter
 /// should be discarded. The pending_violations state is not cleared between uses.
@@ -19,18 +19,18 @@ pub(crate) struct MD013Linter {
 
 impl MD013Linter {
     pub fn new(context: Rc<Context>) -> Self {
-        Self { 
+        Self {
             context,
             pending_violations: RefCell::new(Vec::new()),
         }
     }
-    
+
     /// Analyze all lines and store all violations for reporting via finalize()
     /// Context cache is already initialized by MultiRuleLinter
     fn analyze_all_lines(&self) {
         let lines = self.context.lines.borrow();
         let mut violations = Vec::new();
-        
+
         for (line_index, line) in lines.iter().enumerate() {
             let node_kind = self.context.get_node_type_for_line(line_index);
             let should_check = self.should_check_node_type(&node_kind);
@@ -39,13 +39,13 @@ impl MD013Linter {
             } else {
                 false
             };
-            
+
             if should_violate {
                 let violation = self.create_violation_for_line(line, line_index, &node_kind);
                 violations.push(violation);
             }
         }
-        
+
         *self.pending_violations.borrow_mut() = violations;
     }
 
@@ -82,7 +82,9 @@ impl MD013Linter {
             s if s.starts_with("setext_h") && s.ends_with("_underline") => settings.headings,
             "atx_heading" | "setext_heading" => settings.headings,
             // Code block nodes
-            "fenced_code_block" | "indented_code_block" | "code_fence_content" => settings.code_blocks,
+            "fenced_code_block" | "indented_code_block" | "code_fence_content" => {
+                settings.code_blocks
+            }
             // Table nodes
             "table" | "table_row" => settings.tables,
             _ => true, // Check regular text content
@@ -91,7 +93,7 @@ impl MD013Linter {
 
     fn is_heading_line(&self, line: &str) -> bool {
         let trimmed = line.trim_start();
-        // ATX headings start with # 
+        // ATX headings start with #
         trimmed.starts_with('#') && (trimmed.len() > 1 && trimmed.chars().nth(1) == Some(' '))
     }
 
@@ -100,30 +102,33 @@ impl MD013Linter {
         match node_kind {
             // Heading nodes
             s if s.starts_with("atx_h") && s.ends_with("_marker") => settings.heading_line_length,
-            s if s.starts_with("setext_h") && s.ends_with("_underline") => settings.heading_line_length,
+            s if s.starts_with("setext_h") && s.ends_with("_underline") => {
+                settings.heading_line_length
+            }
             "atx_heading" | "setext_heading" => settings.heading_line_length,
             // Code block nodes
-            "fenced_code_block" | "indented_code_block" | "code_fence_content" => settings.code_block_line_length,
+            "fenced_code_block" | "indented_code_block" | "code_fence_content" => {
+                settings.code_block_line_length
+            }
             _ => settings.line_length,
         }
     }
 
-
     fn should_violate_line(&self, line: &str, _line_number: usize, node_kind: &str) -> bool {
         let settings = &self.context.config.linters.settings.line_length;
-        
+
         // Check if this is a heading line and headings are disabled
         if self.is_heading_line(line) && !settings.headings {
             return false;
         }
-        
+
         // Skip if this node type shouldn't be checked
         if !self.should_check_node_type(node_kind) {
             return false;
         }
 
         let limit = self.get_line_limit(node_kind);
-        
+
         // Check if line exceeds limit
         if line.len() <= limit {
             return false;
@@ -162,8 +167,12 @@ impl MD013Linter {
         true
     }
 
-
-    fn create_violation_for_line(&self, line: &str, line_number: usize, node_kind: &str) -> RuleViolation {
+    fn create_violation_for_line(
+        &self,
+        line: &str,
+        line_number: usize,
+        node_kind: &str,
+    ) -> RuleViolation {
         let limit = self.get_line_limit(node_kind);
         RuleViolation::new(
             &MD013,
@@ -198,7 +207,7 @@ impl RuleLinter for MD013Linter {
             self.analyze_all_lines();
         }
     }
-    
+
     fn finalize(&mut self) -> Vec<RuleViolation> {
         // Return all pending violations at once
         std::mem::take(&mut *self.pending_violations.borrow_mut())
@@ -231,7 +240,9 @@ mod test {
         ])
     }
 
-    fn test_config_with_line_length(line_length_config: MD013LineLengthTable) -> crate::config::QuickmarkConfig {
+    fn test_config_with_line_length(
+        line_length_config: MD013LineLengthTable,
+    ) -> crate::config::QuickmarkConfig {
         test_config_with_settings(
             vec![
                 ("line-length", RuleSeverity::Error),
@@ -245,32 +256,35 @@ mod test {
         )
     }
 
-
     #[test]
     fn test_line_length_violation() {
         let input = "This is a line that is definitely longer than eighty characters and should trigger a violation.";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
         assert_eq!(1, violations.len());
-        
+
         let violation = &violations[0];
         assert_eq!("MD013", violation.rule().id);
         assert!(violation.message().contains("Expected: <= 80"));
-        assert!(violation.message().contains(&format!("Actual: {}", input.len())));
+        assert!(violation
+            .message()
+            .contains(&format!("Actual: {}", input.len())));
     }
 
     #[test]
     fn test_line_length_no_violation() {
-        let mut input = "This line should be exactly eighty characters long and not trigger".to_string();
+        let mut input =
+            "This line should be exactly eighty characters long and not trigger".to_string();
         while input.len() < 80 {
             input.push('x');
         }
         assert_eq!(80, input.len());
-        
+
         let config = test_config();
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
         let violations = linter.analyze();
         assert_eq!(0, violations.len());
     }
@@ -278,7 +292,7 @@ mod test {
     #[test]
     fn test_link_reference_definition_exception() {
         let input = "[very-long-link-reference-that-exceeds-eighty-characters]: https://example.com/very-long-url-that-should-be-exempted";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -288,7 +302,7 @@ mod test {
     #[test]
     fn test_standalone_link_exception() {
         let input = "[This is a very long link text that definitely exceeds eighty characters](https://example.com)";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -298,7 +312,7 @@ mod test {
     #[test]
     fn test_standalone_image_exception() {
         let input = "![This is a very long image alt text that definitely exceeds eighty characters](https://example.com/image.jpg)";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -308,7 +322,7 @@ mod test {
     #[test]
     fn test_no_spaces_beyond_limit_exception() {
         let input = "This line has exactly eighty characters and then continues without spaces: https://example.com/very-long-url-without-spaces";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -318,14 +332,16 @@ mod test {
     #[test]
     fn test_spaces_beyond_limit_violation() {
         // Create a string that exceeds 80 chars with a space beyond the limit
-        let mut input = "This line has exactly eighty characters and should trigger violation".to_string();
+        let mut input =
+            "This line has exactly eighty characters and should trigger violation".to_string();
         while input.len() < 80 {
             input.push('x');
         }
         input.push(' '); // Add space beyond limit
-        
+
         let config = test_config();
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
         let violations = linter.analyze();
         assert_eq!(1, violations.len());
     }
@@ -336,9 +352,9 @@ mod test {
             strict: true,
             ..MD013LineLengthTable::default()
         };
-        
+
         let input = "This line has exactly eighty characters and then continues without spaces like: https://example.com/url";
-        
+
         let config = test_config_with_line_length(line_length_config);
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -351,33 +367,36 @@ mod test {
             stern: true,
             ..MD013LineLengthTable::default()
         };
-        
+
         // Line with spaces beyond limit - should violate in stern mode
         // Make sure the line has exactly 80 chars, then add text with spaces beyond that
-        let mut input = "This line has exactly eighty characters and should trigger violations".to_string();
+        let mut input =
+            "This line has exactly eighty characters and should trigger violations".to_string();
         while input.len() < 80 {
             input.push('x');
         }
         input.push_str(" with spaces"); // Add spaces beyond limit
-        
+
         let full_config = test_config_with_line_length(config);
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), full_config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), full_config, &input);
         let violations = linter.analyze();
         assert_eq!(1, violations.len()); // Should violate in stern mode
     }
 
-    #[test] 
+    #[test]
     fn test_stern_mode_without_spaces_beyond_limit() {
         let config = MD013LineLengthTable {
             stern: true,
             ..MD013LineLengthTable::default()
         };
-        
+
         // Line without spaces beyond limit - should NOT violate in stern mode
         let input = "This line has exactly eighty characters and then continues without spaces: https://example.com/very-long-url-without-spaces";
-        
+
         let full_config = test_config_with_line_length(config);
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), full_config, input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), full_config, input);
         let violations = linter.analyze();
         assert_eq!(0, violations.len()); // Should NOT violate in stern mode
     }
@@ -385,27 +404,33 @@ mod test {
     #[test]
     fn test_stern_mode_vs_default_mode() {
         // Create line that exceeds limit with spaces beyond limit
-        let mut input = "This line has exactly eighty characters and then continues with".to_string();
+        let mut input =
+            "This line has exactly eighty characters and then continues with".to_string();
         while input.len() < 80 {
             input.push('x');
         }
         input.push_str(" spaces beyond"); // Add spaces beyond limit
-        
+
         // Default mode - should violate because there are spaces beyond limit
         let default_config = MD013LineLengthTable::default();
         let default_full_config = test_config_with_line_length(default_config);
-        let mut default_linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), default_full_config, &input);
+        let mut default_linter = MultiRuleLinter::new_for_document(
+            PathBuf::from("test.md"),
+            default_full_config,
+            &input,
+        );
         let default_violations = default_linter.analyze();
-        
+
         // Stern mode - should violate because it's more aggressive about lines with spaces
         let stern_config = MD013LineLengthTable {
             stern: true,
             ..MD013LineLengthTable::default()
         };
         let stern_full_config = test_config_with_line_length(stern_config);
-        let mut stern_linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), stern_full_config, &input);
+        let mut stern_linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), stern_full_config, &input);
         let stern_violations = stern_linter.analyze();
-        
+
         // Both should catch this since it has spaces beyond limit
         assert_eq!(1, default_violations.len()); // Default should catch this since it has spaces
         assert_eq!(1, stern_violations.len()); // Stern should definitely catch this
@@ -414,54 +439,76 @@ mod test {
     #[test]
     fn test_stern_vs_strict_vs_default_comprehensive() {
         // Case 1: Line with spaces beyond limit - all modes should catch this
-        let mut case1 = "This line has exactly eighty characters and then continues with".to_string();
+        let mut case1 =
+            "This line has exactly eighty characters and then continues with".to_string();
         while case1.len() < 80 {
             case1.push('x');
         }
         case1.push_str(" spaces"); // Add spaces beyond limit
 
-        // Case 2: Line without spaces beyond limit - only strict mode should catch this  
+        // Case 2: Line without spaces beyond limit - only strict mode should catch this
         let case2 = "This line has exactly eighty characters and then continues without spaces: https://example.com/url".to_string();
 
         // Case 3: Line within limit - no mode should catch this
         let case3 = "This line is within the eighty character limit".to_string();
 
         let test_cases = vec![
-            (&case1, true, true, true),   // Has spaces beyond limit
-            (&case2, false, false, true), // No spaces beyond limit  
+            (&case1, true, true, true),    // Has spaces beyond limit
+            (&case2, false, false, true),  // No spaces beyond limit
             (&case3, false, false, false), // Within limit
         ];
-        
+
         for (input, expect_default, expect_stern, expect_strict) in test_cases {
             // Default mode
             let default_config = MD013LineLengthTable::default();
             let default_full_config = test_config_with_line_length(default_config);
-            let mut default_linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), default_full_config, input);
+            let mut default_linter = MultiRuleLinter::new_for_document(
+                PathBuf::from("test.md"),
+                default_full_config,
+                input,
+            );
             let default_violations = default_linter.analyze();
-            assert_eq!(expect_default, !default_violations.is_empty(), 
-                "Default mode failed for: {input}");
-            
+            assert_eq!(
+                expect_default,
+                !default_violations.is_empty(),
+                "Default mode failed for: {input}"
+            );
+
             // Stern mode
             let stern_config = MD013LineLengthTable {
                 stern: true,
                 ..MD013LineLengthTable::default()
             };
             let stern_full_config = test_config_with_line_length(stern_config);
-            let mut stern_linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), stern_full_config, input);
+            let mut stern_linter = MultiRuleLinter::new_for_document(
+                PathBuf::from("test.md"),
+                stern_full_config,
+                input,
+            );
             let stern_violations = stern_linter.analyze();
-            assert_eq!(expect_stern, !stern_violations.is_empty(),
-                "Stern mode failed for: {input}");
-            
+            assert_eq!(
+                expect_stern,
+                !stern_violations.is_empty(),
+                "Stern mode failed for: {input}"
+            );
+
             // Strict mode
             let strict_config = MD013LineLengthTable {
                 strict: true,
                 ..MD013LineLengthTable::default()
             };
             let strict_full_config = test_config_with_line_length(strict_config);
-            let mut strict_linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), strict_full_config, input);
+            let mut strict_linter = MultiRuleLinter::new_for_document(
+                PathBuf::from("test.md"),
+                strict_full_config,
+                input,
+            );
             let strict_violations = strict_linter.analyze();
-            assert_eq!(expect_strict, !strict_violations.is_empty(),
-                "Strict mode failed for: {input}");
+            assert_eq!(
+                expect_strict,
+                !strict_violations.is_empty(),
+                "Strict mode failed for: {input}"
+            );
         }
     }
 
@@ -471,9 +518,9 @@ mod test {
             line_length: 50,
             ..MD013LineLengthTable::default()
         };
-        
+
         let input = "This line is longer than fifty characters and should violate";
-        
+
         let config = test_config_with_line_length(line_length_config);
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -487,9 +534,9 @@ mod test {
             headings: false,
             ..MD013LineLengthTable::default()
         };
-        
+
         let input = "# This is a very long heading that definitely exceeds the eighty character limit and should not trigger a violation";
-        
+
         let config = test_config_with_line_length(line_length_config);
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
@@ -501,35 +548,40 @@ mod test {
         let input = "This is a short line.
 This is a very long line that definitely exceeds the eighty character limit and should trigger a violation.
 Another short line.";
-        
+
         let config = test_config();
         let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
         let violations = linter.analyze();
         assert_eq!(1, violations.len());
     }
 
-    #[test] 
+    #[test]
     fn test_demonstrates_potential_bug_scenario() {
         // This test demonstrates that our concern was valid in theory, but doesn't occur in practice
         // because tree-sitter creates enough AST nodes for even simple documents
-        
+
         let input = "A\nB\nC\n"; // Minimal document - just 3 short lines
-        
+
         // Count AST nodes for this minimal document
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_md::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(input, None).unwrap();
         let mut node_count = 0;
         let walker = crate::tree_sitter_walker::TreeSitterWalker::new(&tree);
         walker.walk(|_node| {
             node_count += 1;
         });
-        
+
         println!("Even a 3-line minimal document creates {node_count} AST nodes");
         println!("This explains why our MD013 implementation works correctly");
-        
+
         // Even this tiny document creates multiple nodes (document, paragraph, text nodes, etc.)
-        assert!(node_count >= 3, "Even minimal documents create multiple AST nodes");
+        assert!(
+            node_count >= 3,
+            "Even minimal documents create multiple AST nodes"
+        );
     }
 
     #[test]
@@ -537,21 +589,27 @@ Another short line.";
         // Create the most minimal AST possible: just plain text with no structure
         // This should create minimal AST nodes but many violations
         let mut input = String::new();
-        
+
         // Add 100 long lines of plain text (no markdown structure at all)
         let long_line = "This line is definitely longer than 80 characters and should trigger a line length violation every single time.\n";
-        assert!(long_line.len() > 80, "Test line should exceed 80 chars, got {}", long_line.len());
-        
+        assert!(
+            long_line.len() > 80,
+            "Test line should exceed 80 chars, got {}",
+            long_line.len()
+        );
+
         for i in 0..100 {
             input.push_str(&format!("Violation line {}: {}", i + 1, long_line));
         }
-        
+
         println!("Total input length: {} chars", input.len());
         println!("Number of lines: {}", input.lines().count());
-        
+
         // Count how many AST nodes are created by parsing this document
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_md::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(&input, None).unwrap();
         let mut node_count = 0;
         let walker = crate::tree_sitter_walker::TreeSitterWalker::new(&tree);
@@ -559,63 +617,81 @@ Another short line.";
             node_count += 1;
         });
         println!("Total AST nodes: {node_count}");
-        
+
         let config = test_config();
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
         let violations = linter.analyze();
-        
+
         println!("Violations found: {}", violations.len());
-        
+
         // This is the critical test: with the improved MD013, we should ALWAYS find all violations
         // regardless of the node count, because violations are tied to line numbers, not node traversal order
-        println!("Ratio: {} violations vs {} nodes", violations.len(), node_count);
-        
+        println!(
+            "Ratio: {} violations vs {} nodes",
+            violations.len(),
+            node_count
+        );
+
         // We should find exactly 100 violations
-        assert_eq!(100, violations.len(), 
+        assert_eq!(100, violations.len(),
             "Expected 100 line length violations but found {}. The improved MD013 should never lose violations!",
             violations.len()
         );
     }
-    
+
     #[test]
     fn test_violation_node_mismatch_scenario() {
         // This test creates a scenario where violations > nodes to ensure our fix works
         // Create a document with minimal structure but maximum line violations
-        
+
         let mut input = "# Header\n\n".to_string(); // Creates multiple AST nodes
-        
+
         // Add 50 long lines that should violate but may not have corresponding unique AST nodes
         for i in 0..50 {
             input.push_str(&format!("Line {} with text that is definitely over eighty characters and should trigger MD013 violation\n", i + 1));
         }
-        
+
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_md::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
         let tree = parser.parse(&input, None).unwrap();
         let mut node_count = 0;
         let walker = crate::tree_sitter_walker::TreeSitterWalker::new(&tree);
         walker.walk(|_node| {
             node_count += 1;
         });
-        
+
         let config = test_config();
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
         let violations = linter.analyze();
-        
-        println!("Stress test: {} violations vs {} nodes", violations.len(), node_count);
-        
+
+        println!(
+            "Stress test: {} violations vs {} nodes",
+            violations.len(),
+            node_count
+        );
+
         // Should find exactly 50 violations (one per long line), regardless of node count
-        assert_eq!(50, violations.len(), 
-            "Expected 50 violations but found {}. Improved MD013 must not lose violations!", 
+        assert_eq!(
+            50,
+            violations.len(),
+            "Expected 50 violations but found {}. Improved MD013 must not lose violations!",
             violations.len()
         );
-        
+
         // Verify each violation is on the correct line
         for (i, violation) in violations.iter().enumerate() {
             let expected_line = i + 2; // Lines 2, 3, 4, ..., 51 (line 0 is header, line 1 is empty)
-            assert_eq!(expected_line, violation.location().range.start.line,
-                "Violation {} should be on line {} but was on line {}", 
-                i + 1, expected_line, violation.location().range.start.line
+            assert_eq!(
+                expected_line,
+                violation.location().range.start.line,
+                "Violation {} should be on line {} but was on line {}",
+                i + 1,
+                expected_line,
+                violation.location().range.start.line
             );
         }
     }
@@ -625,41 +701,54 @@ Another short line.";
         // Create a document with many line violations but few AST nodes
         // Structure: simple heading followed by many long lines of plain text
         let mut input = "# Short heading\n\n".to_string();
-        
+
         // Add 20 long lines that should each trigger violations
         let long_line = "This line is definitely longer than 80 characters and should trigger a line length violation every time it appears.\n";
-        assert!(long_line.len() > 80, "Test line should exceed 80 chars, got {}", long_line.len());
-        
+        assert!(
+            long_line.len() > 80,
+            "Test line should exceed 80 chars, got {}",
+            long_line.len()
+        );
+
         for i in 0..20 {
             input.push_str(&format!("Line {}: {}", i + 1, long_line));
         }
-        
+
         println!("Total input length: {} chars", input.len());
         println!("Number of lines: {}", input.lines().count());
-        
+
         let config = test_config();
-        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
+        let mut linter =
+            MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, &input);
         let violations = linter.analyze();
-        
+
         // Debug: print actual violations found
         println!("Violations found: {}", violations.len());
         for (i, violation) in violations.iter().enumerate() {
-            println!("  Violation {}: line {}", i + 1, violation.location().range.start.line);
+            println!(
+                "  Violation {}: line {}",
+                i + 1,
+                violation.location().range.start.line
+            );
         }
-        
+
         // We should find exactly 20 violations (one per long line)
         // If we find fewer, it means some violations were lost due to the bug
-        assert_eq!(20, violations.len(), 
+        assert_eq!(20, violations.len(),
             "Expected 20 line length violations but found {}. This suggests violations were lost due to insufficient AST nodes.",
             violations.len()
         );
-        
+
         // Verify violations are on the correct lines (lines 2-21, since line 0 is heading, line 1 is empty)
         for (i, violation) in violations.iter().enumerate() {
             let expected_line = i + 2; // Lines 2, 3, 4, ..., 21
-            assert_eq!(expected_line, violation.location().range.start.line,
-                "Violation {} should be on line {} but was on line {}", 
-                i + 1, expected_line, violation.location().range.start.line
+            assert_eq!(
+                expected_line,
+                violation.location().range.start.line,
+                "Violation {} should be on line {} but was on line {}",
+                i + 1,
+                expected_line,
+                violation.location().range.start.line
             );
         }
     }

--- a/crates/quickmark_linter/src/rules/md053.rs
+++ b/crates/quickmark_linter/src/rules/md053.rs
@@ -1,0 +1,561 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use tree_sitter::Node;
+
+use crate::{
+    linter::{range_from_tree_sitter, RuleViolation},
+    rules::{Context, Rule, RuleLinter, RuleType},
+};
+
+// Pre-compiled regex patterns for performance
+static FULL_REFERENCE_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\[([^\]]*)\]\[([^\]]*)\]").unwrap());
+
+static COLLAPSED_REFERENCE_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\[([^\]]+)\]\[\]").unwrap());
+
+static SHORTCUT_REFERENCE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[([^\]]+)\]").unwrap());
+
+static REFERENCE_DEFINITION_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?m)^\s*\[([^\]]+)\]:\s*").unwrap());
+
+#[derive(Debug, Clone)]
+struct ReferenceDefinition {
+    label: String,
+    range: tree_sitter::Range,
+}
+
+pub(crate) struct MD053Linter {
+    context: Rc<Context>,
+    definitions: HashMap<String, Vec<ReferenceDefinition>>, // Track multiple definitions per label
+    references: HashSet<String>,                            // All referenced labels
+}
+
+impl MD053Linter {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            definitions: HashMap::new(),
+            references: HashSet::new(),
+        }
+    }
+
+    fn normalize_reference(&self, label: &str) -> String {
+        // Normalize reference labels according to CommonMark spec:
+        // - Convert to lowercase
+        // - Trim whitespace
+        // - Collapse consecutive whitespace to single spaces
+        let mut result = String::with_capacity(label.len());
+        let mut prev_was_space = false;
+
+        for ch in label.chars() {
+            if ch.is_whitespace() {
+                if !prev_was_space && !result.is_empty() {
+                    result.push(' ');
+                    prev_was_space = true;
+                }
+            } else {
+                result.push(ch.to_lowercase().next().unwrap_or(ch));
+                prev_was_space = false;
+            }
+        }
+
+        // Remove trailing space if present
+        if result.ends_with(' ') {
+            result.pop();
+        }
+
+        result
+    }
+
+    fn extract_reference_definition(&self, node: &Node) -> Vec<ReferenceDefinition> {
+        // Extract the label from reference definition nodes
+        // [label]: url "title"
+        let start_byte = node.start_byte();
+        let end_byte = node.end_byte();
+        let document_content = self.context.document_content.borrow();
+        let content = &document_content[start_byte..end_byte];
+
+        REFERENCE_DEFINITION_PATTERN
+            .captures_iter(content)
+            .filter_map(|cap| {
+                cap.get(1).map(|label| {
+                    let normalized_label = self.normalize_reference(label.as_str());
+                    ReferenceDefinition {
+                        label: normalized_label,
+                        range: node.range(),
+                    }
+                })
+            })
+            .collect()
+    }
+
+    fn extract_reference_links(&self, node: &Node) -> Vec<String> {
+        // Extract reference links in different formats:
+        // Full: [text][label]
+        // Collapsed: [label][]
+        // Shortcut: [label]
+        let start_byte = node.start_byte();
+        let end_byte = node.end_byte();
+        let document_content = self.context.document_content.borrow();
+        let content = &document_content[start_byte..end_byte];
+
+        let mut links = Vec::new();
+
+        // Check for inline links first (contain parentheses - not reference links)
+        if content.contains('(') && content.contains(')') {
+            return links; // This is an inline link, not a reference link
+        }
+
+        // Full reference: [text][label]
+        for cap in FULL_REFERENCE_PATTERN.captures_iter(content) {
+            if let Some(label) = cap.get(2) {
+                let label_str = label.as_str();
+                if !label_str.is_empty() {
+                    links.push(self.normalize_reference(label_str));
+                }
+            }
+        }
+
+        // Collapsed reference: [label][]
+        for cap in COLLAPSED_REFERENCE_PATTERN.captures_iter(content) {
+            if let Some(label) = cap.get(1) {
+                links.push(self.normalize_reference(label.as_str()));
+            }
+        }
+
+        // Shortcut reference: [label] - check all potential shortcuts
+        // We need to be careful not to double-count references that were already caught by full/collapsed patterns
+        let mut shortcut_candidates = Vec::new();
+        for cap in SHORTCUT_REFERENCE_PATTERN.captures_iter(content) {
+            if let Some(label) = cap.get(1) {
+                let full_match = cap.get(0).expect("regex match should have group 0");
+                let start = full_match.start();
+                let end = full_match.end();
+                let remaining = &content[end..];
+
+                // Check if this looks like a shortcut (not immediately followed by [] or [label])
+                // We only reject if immediately followed by brackets, not if there's whitespace/newline first
+                let immediately_followed_by_bracket = remaining.starts_with('[');
+                if !immediately_followed_by_bracket {
+                    shortcut_candidates.push((
+                        start,
+                        end,
+                        self.normalize_reference(label.as_str()),
+                    ));
+                }
+            }
+        }
+
+        // Filter out shortcut candidates that overlap with already found full/collapsed references
+        // Use a HashSet for O(1) lookup performance
+        let mut existing_labels: HashSet<String> = links.iter().cloned().collect();
+        for (_start, _end, normalized_label) in shortcut_candidates {
+            // Check if this shortcut overlaps with any full/collapsed reference we already found
+            // For now, we'll use a simple heuristic: if we didn't find this as a full/collapsed reference,
+            // and it's not followed by brackets, treat it as a shortcut
+            if !existing_labels.contains(&normalized_label) {
+                existing_labels.insert(normalized_label.clone());
+                links.push(normalized_label);
+            }
+        }
+
+        links
+    }
+}
+
+impl RuleLinter for MD053Linter {
+    fn feed(&mut self, node: &Node) {
+        match node.kind() {
+            // Handle reference definitions like [label]: url
+            "link_reference_definition" => {
+                let definitions = self.extract_reference_definition(node);
+                for definition in definitions {
+                    self.definitions
+                        .entry(definition.label.clone())
+                        .or_default()
+                        .push(definition);
+                }
+            }
+            // Handle paragraphs for reference links
+            "paragraph" => {
+                let links = self.extract_reference_links(node);
+                for link in links {
+                    self.references.insert(link);
+                }
+            }
+            // Handle reference links [text][label], [label][], [label]
+            "link" | "image" => {
+                let links = self.extract_reference_links(node);
+                for link in links {
+                    self.references.insert(link);
+                }
+            }
+            _ => {
+                // Ignore other node types
+            }
+        }
+    }
+
+    fn finalize(&mut self) -> Vec<RuleViolation> {
+        let mut violations = Vec::new();
+        let config = &self
+            .context
+            .config
+            .linters
+            .settings
+            .link_image_reference_definitions;
+        let ignored_definitions: HashSet<String> = config
+            .ignored_definitions
+            .iter()
+            .map(|label| self.normalize_reference(label))
+            .collect();
+
+        // Check for unused definitions and duplicates
+        for (label, definitions) in &self.definitions {
+            // Skip if label is in ignored list
+            if ignored_definitions.contains(label) {
+                continue;
+            }
+
+            // Check if definition is unused (no references to it)
+            let is_unused = !self.references.contains(label);
+
+            if definitions.len() > 1 {
+                // Handle duplicate definitions
+                if is_unused {
+                    // If unused, report the first definition as unused
+                    let first_def = &definitions[0];
+                    violations.push(RuleViolation::new(
+                        &MD053,
+                        format!(
+                            "Unused link or image reference definition: \"{}\"",
+                            first_def.label
+                        ),
+                        self.context.file_path.clone(),
+                        range_from_tree_sitter(&first_def.range),
+                    ));
+                }
+                // Report all subsequent definitions as duplicates (first definition wins per CommonMark)
+                for definition in &definitions[1..] {
+                    violations.push(RuleViolation::new(
+                        &MD053,
+                        format!(
+                            "Duplicate link or image reference definition: \"{}\"",
+                            definition.label
+                        ),
+                        self.context.file_path.clone(),
+                        range_from_tree_sitter(&definition.range),
+                    ));
+                }
+            } else if is_unused {
+                // Single definition that is unused
+                let def = &definitions[0];
+                violations.push(RuleViolation::new(
+                    &MD053,
+                    format!(
+                        "Unused link or image reference definition: \"{}\"",
+                        def.label
+                    ),
+                    self.context.file_path.clone(),
+                    range_from_tree_sitter(&def.range),
+                ));
+            }
+        }
+
+        violations
+    }
+}
+
+pub const MD053: Rule = Rule {
+    id: "MD053",
+    alias: "link-image-reference-definitions",
+    tags: &["links", "images"],
+    description: "Link and image reference definitions should be needed",
+    rule_type: RuleType::Document,
+    required_nodes: &["link", "image", "paragraph", "link_reference_definition"],
+    new_linter: |context| Box::new(MD053Linter::new(context)),
+};
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::config::{
+        LintersSettingsTable, MD053LinkImageReferenceDefinitionsTable, RuleSeverity,
+    };
+    use crate::linter::MultiRuleLinter;
+    use crate::test_utils::test_helpers::test_config_with_rules;
+
+    fn test_config() -> crate::config::QuickmarkConfig {
+        test_config_with_rules(vec![(
+            "link-image-reference-definitions",
+            RuleSeverity::Error,
+        )])
+    }
+
+    fn test_config_with_ignored_definitions(
+        ignored_definitions: Vec<String>,
+    ) -> crate::config::QuickmarkConfig {
+        crate::test_utils::test_helpers::test_config_with_settings(
+            vec![("link-image-reference-definitions", RuleSeverity::Error)],
+            LintersSettingsTable {
+                link_image_reference_definitions: MD053LinkImageReferenceDefinitionsTable {
+                    ignored_definitions,
+                },
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn test_unused_definition_basic() {
+        let input = "[unused]: https://example.com
+
+Some text.
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 1 violation - unused reference definition
+        assert_eq!(1, violations.len());
+        assert!(violations[0]
+            .message()
+            .contains("Unused link or image reference definition: \"unused\""));
+    }
+
+    #[test]
+    fn test_used_definition_basic() {
+        let input = "[label]: https://example.com
+
+[Good link][label]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - definition is used
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_duplicate_definitions() {
+        let input = "[label]: https://example.com/1
+[label]: https://example.com/2
+
+[Good link][label]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 1 violation - duplicate definition (second one)
+        assert_eq!(1, violations.len());
+        assert!(violations[0]
+            .message()
+            .contains("Duplicate link or image reference definition: \"label\""));
+    }
+
+    #[test]
+    fn test_unused_and_duplicate() {
+        let input = "[unused1]: https://example.com/1
+[unused2]: https://example.com/2
+[duplicate]: https://example.com/3
+[duplicate]: https://example.com/4
+
+Some text.
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 4 violations: 2 unused + 1 duplicate + 1 unused (both duplicates are unused)
+        assert_eq!(4, violations.len());
+
+        // Check violation types
+        let messages: Vec<&str> = violations.iter().map(|v| v.message()).collect();
+        let unused_count = messages.iter().filter(|m| m.contains("Unused")).count();
+        let duplicate_count = messages.iter().filter(|m| m.contains("Duplicate")).count();
+
+        assert_eq!(3, unused_count); // unused1, unused2, and both duplicate entries are unused
+        assert_eq!(1, duplicate_count); // second duplicate entry
+    }
+
+    #[test]
+    fn test_collapsed_reference_format() {
+        let input = "[label]: https://example.com
+
+[label][]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - collapsed reference is used
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_shortcut_reference_format() {
+        let input = "[label]: https://example.com
+
+[label]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - shortcut reference is used
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_image_references() {
+        let input = "[image]: https://example.com/image.png
+[unused-image]: https://example.com/unused.png
+
+![Alt text][image]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 1 violation - unused image reference
+        assert_eq!(1, violations.len());
+        assert!(violations[0]
+            .message()
+            .contains("Unused link or image reference definition: \"unused-image\""));
+    }
+
+    #[test]
+    fn test_case_insensitive_matching() {
+        let input = "[Label]: https://example.com
+
+[Good link][LABEL]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - case insensitive matching per CommonMark
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_whitespace_normalization() {
+        let input = "[  label   with   spaces  ]: https://example.com
+
+[Good link][label with spaces]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - whitespace is normalized per CommonMark
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_ignored_definitions_default() {
+        let input = "[//]: # (This is a comment)
+[unused]: https://example.com
+
+Some text.
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 1 violation - '//' is ignored by default, but 'unused' is not
+        assert_eq!(1, violations.len());
+        assert!(violations[0]
+            .message()
+            .contains("Unused link or image reference definition: \"unused\""));
+    }
+
+    #[test]
+    fn test_custom_ignored_definitions() {
+        let input = "[custom]: https://example.com
+[another]: https://example.com
+[regular]: https://example.com
+
+[Good link][regular]
+";
+
+        let config =
+            test_config_with_ignored_definitions(vec!["custom".to_string(), "another".to_string()]);
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have no violations - custom and another are ignored, regular is used
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_mixed_scenarios_comprehensive() {
+        let input = "[used-full]: https://example.com/1
+[used-collapsed]: https://example.com/2
+[used-shortcut]: https://example.com/3
+[unused]: https://example.com/4
+[duplicate-used]: https://example.com/5
+[duplicate-used]: https://example.com/6
+[duplicate-unused]: https://example.com/7
+[duplicate-unused]: https://example.com/8
+[//]: # (Ignored comment)
+
+[Link 1][used-full]
+[used-collapsed][]
+[used-shortcut]
+[Link 2][duplicate-used]
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Expected violations:
+        // - unused: unused
+        // - duplicate-used (second): duplicate
+        // - duplicate-unused (first): unused
+        // - duplicate-unused (second): duplicate
+        assert_eq!(4, violations.len());
+
+        let messages: Vec<&str> = violations.iter().map(|v| v.message()).collect();
+        let unused_count = messages.iter().filter(|m| m.contains("Unused")).count();
+        let duplicate_count = messages.iter().filter(|m| m.contains("Duplicate")).count();
+
+        assert_eq!(2, unused_count); // unused + duplicate_unused (first)
+        assert_eq!(2, duplicate_count); // duplicate-used (second) + duplicate-unused (second)
+    }
+
+    #[test]
+    fn test_inline_links_ignored() {
+        let input = "[unused]: https://example.com
+
+[Inline link](https://example.com) and [another](https://example.com).
+";
+
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+
+        // Should have 1 violation - unused definition, inline links don't count as references
+        assert_eq!(1, violations.len());
+        assert!(violations[0]
+            .message()
+            .contains("Unused link or image reference definition: \"unused\""));
+    }
+}

--- a/crates/quickmark_linter/src/rules/mod.rs
+++ b/crates/quickmark_linter/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub mod md003;
 pub mod md013;
 pub mod md051;
 pub mod md052;
+pub mod md053;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuleType {
@@ -29,4 +30,11 @@ pub struct Rule {
     pub new_linter: fn(Rc<Context>) -> Box<dyn RuleLinter>,
 }
 
-pub const ALL_RULES: &[Rule] = &[md001::MD001, md003::MD003, md013::MD013, md051::MD051, md052::MD052];
+pub const ALL_RULES: &[Rule] = &[
+    md001::MD001,
+    md003::MD003,
+    md013::MD013,
+    md051::MD051,
+    md052::MD052,
+    md053::MD053,
+];

--- a/crates/quickmark_linter/src/test_utils.rs
+++ b/crates/quickmark_linter/src/test_utils.rs
@@ -1,23 +1,23 @@
 //! Testing utilities for QuickMark linter rules.
-//! 
+//!
 //! This module provides shared functions to create test configurations,
 //! avoiding code duplication across individual rule tests.
 
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers {
-    use std::collections::HashMap;
     use crate::config::{LintersSettingsTable, LintersTable, QuickmarkConfig, RuleSeverity};
+    use std::collections::HashMap;
 
     /// Creates a basic test configuration with only the specified rules enabled.
-    /// 
+    ///
     /// # Arguments
     /// * `enabled_rules` - Vector of (rule_name, severity) tuples to enable
-    /// 
+    ///
     /// # Example
     /// ```
     /// use quickmark_linter::test_utils::test_helpers::test_config_with_rules;
     /// use quickmark_linter::config::RuleSeverity;
-    /// 
+    ///
     /// let config = test_config_with_rules(vec![
     ///     ("heading-increment", RuleSeverity::Error),
     ///     ("heading-style", RuleSeverity::Warning),
@@ -28,7 +28,7 @@ pub mod test_helpers {
             .into_iter()
             .map(|(rule, sev)| (rule.to_string(), sev))
             .collect();
-            
+
         QuickmarkConfig {
             linters: LintersTable {
                 severity,
@@ -38,16 +38,16 @@ pub mod test_helpers {
     }
 
     /// Creates a test configuration with custom settings.
-    /// 
+    ///
     /// # Arguments
     /// * `enabled_rules` - Vector of (rule_name, severity) tuples to enable
     /// * `settings` - Custom linter settings
-    /// 
+    ///
     /// # Example
     /// ```
     /// use quickmark_linter::test_utils::test_helpers::test_config_with_settings;
     /// use quickmark_linter::config::{RuleSeverity, LintersSettingsTable, MD003HeadingStyleTable, HeadingStyle};
-    /// 
+    ///
     /// let config = test_config_with_settings(
     ///     vec![("heading-style", RuleSeverity::Error)],
     ///     LintersSettingsTable {
@@ -64,12 +64,9 @@ pub mod test_helpers {
             .into_iter()
             .map(|(rule, sev)| (rule.to_string(), sev))
             .collect();
-            
+
         QuickmarkConfig {
-            linters: LintersTable {
-                severity,
-                settings,
-            },
+            linters: LintersTable { severity, settings },
         }
     }
 }

--- a/crates/quickmark_linter/src/tree_sitter_walker.rs
+++ b/crates/quickmark_linter/src/tree_sitter_walker.rs
@@ -2,14 +2,14 @@ use tree_sitter::{Node, Tree};
 
 #[derive(Copy, Clone, Debug)]
 pub enum TraversalOrder {
-        PreOrder,
-        PostOrder,
+    PreOrder,
+    PostOrder,
 }
 
 #[derive(Debug)]
 pub struct TreeSitterWalker<'a> {
     pub order: TraversalOrder,
-    pub tree: &'a Tree
+    pub tree: &'a Tree,
 }
 
 impl<'a> TreeSitterWalker<'a> {
@@ -30,7 +30,6 @@ impl<'a> TreeSitterWalker<'a> {
             TraversalOrder::PreOrder => self.walk_pre_order(root, &mut callback),
             TraversalOrder::PostOrder => self.walk_post_order(root, &mut callback),
         }
-
     }
 
     #[allow(clippy::only_used_in_recursion)]

--- a/docs/rules/md053.md
+++ b/docs/rules/md053.md
@@ -1,0 +1,38 @@
+# `MD053` - Link and image reference definitions should be needed
+
+Tags: `images`, `links`
+
+Aliases: `link-image-reference-definitions`
+
+Parameters:
+
+- `ignored_definitions`: Ignored definitions (`string[]`, default `["//"]`)
+
+Fixable: Some violations can be fixed by tooling
+
+Links and images in Markdown can provide the link destination or image source
+at the time of use or can use a label to reference a definition elsewhere in
+the document. The latter reference format is convenient for keeping paragraph
+text clutter-free and makes it easy to reuse the same URL in multiple places.
+
+Because link and image reference definitions are located separately from
+where they are used, there are two scenarios where a definition can be
+unnecessary:
+
+1. If a label is not referenced by any link or image in a document, that
+   definition is unused and can be deleted.
+2. If a label is defined multiple times in a document, the first definition is
+   used and the others can be deleted.
+
+This rule considers a reference definition to be used if any link or image
+reference has the corresponding label. The "full", "collapsed", and "shortcut"
+formats are all supported.
+
+If there are reference definitions that are deliberately unreferenced, they can
+be ignored by setting the `ignored_definitions` parameter to the list of strings
+to ignore. The default value of this parameter ignores the following convention
+for adding non-HTML comments to Markdown:
+
+```markdown
+[//]: # (This behaves like a comment)
+```

--- a/test-samples/test_md053_comprehensive.md
+++ b/test-samples/test_md053_comprehensive.md
@@ -1,0 +1,65 @@
+# Test MD053 Comprehensive
+
+This file contains a comprehensive set of test cases for MD053 rule validation.
+
+## Valid Scenarios
+
+### All Reference Types Used
+
+[Full reference][valid_full]
+[valid_collapsed][]
+[valid_shortcut]
+
+![Image reference][valid_image]
+
+### Case Insensitive and Whitespace Normalization
+
+[Mixed case reference][VALID_CASE]
+[Whitespace reference][  valid_spaces  ]
+
+### Ignored Definitions
+
+[//]: # (This is a comment - should be ignored)
+[//]: <> (Another comment - should be ignored)
+
+## Violation Scenarios
+
+### Unused Definitions
+
+Some text without any references to unused definitions.
+
+### Duplicate Definitions
+
+[Reference to first duplicate][duplicate_referenced]
+
+### Multiple Issues
+
+Some text with [valid ref][valid_multi] but no reference to unused_multi.
+
+## Reference Definitions
+
+### Valid Definitions (Used)
+
+[valid_full]: https://example.com/valid_full
+[valid_collapsed]: https://example.com/valid_collapsed
+[valid_shortcut]: https://example.com/valid_shortcut
+[valid_image]: https://example.com/valid_image.png
+[valid_case]: https://example.com/valid_case
+[valid_spaces]: https://example.com/valid_spaces
+[duplicate_referenced]: https://example.com/first_duplicate
+[duplicate_referenced]: https://example.com/second_duplicate
+[valid_multi]: https://example.com/valid_multi
+
+### Invalid Definitions (Unused)
+
+[unused_simple]: https://example.com/unused_simple
+[unused_complex]: https://example.com/unused_complex "Title"
+
+### Invalid Definitions (Duplicate)
+
+[duplicate_unused]: https://example.com/dup1
+[duplicate_unused]: https://example.com/dup2
+
+### Mixed Invalid
+
+[unused_multi]: https://example.com/unused_multi

--- a/test-samples/test_md053_valid.md
+++ b/test-samples/test_md053_valid.md
@@ -1,0 +1,54 @@
+# Test MD053 Valid Cases
+
+This file contains reference definitions that should not trigger MD053 violations.
+
+## All References Used
+
+[Valid full reference][label1]
+[Another full reference][label2]
+
+[label1][]
+[label2][]
+
+![Valid image][image1]
+![Another image][image2]
+
+## Shortcut References
+
+[label3]
+[label4]
+
+## Case Insensitive Matching
+
+[Valid case insensitive][LABEL5]
+[Mixed Case][Label6]
+
+## Whitespace Normalization
+
+[Valid with spaces][  label7  ]
+[Valid with tabs][	label8	]
+
+## Duplicate Definitions (first one is used)
+
+[Valid duplicate reference][duplicate]
+
+## Ignored Definitions
+
+[//]: # (This is a comment)
+[//]: <> (Another comment)
+
+## Reference Definitions
+
+[label1]: https://example.com/1
+[label2]: https://example.com/2
+[label3]: https://example.com/3
+[label4]: https://example.com/4
+[label5]: https://example.com/5
+[label6]: https://example.com/6
+[label7]: https://example.com/7
+[label8]: https://example.com/8
+[image1]: https://example.com/image1.png
+[image2]: https://example.com/image2.png
+
+[duplicate]: https://example.com/first
+[duplicate]: https://example.com/second

--- a/test-samples/test_md053_violations.md
+++ b/test-samples/test_md053_violations.md
@@ -1,0 +1,39 @@
+# Test MD053 Violations
+
+This file contains reference definitions that should trigger MD053 violations.
+
+## Unused Definitions
+
+[Valid reference][used1]
+
+Some text content.
+
+## Multiple Unused Definitions
+
+Some more content without any references.
+
+## Duplicate Definitions (unused)
+
+Some text that doesn't reference anything.
+
+## Duplicate Definitions (used)
+
+[Valid reference to duplicated][duplicate_used]
+
+## Mixed Scenarios
+
+[Valid reference][mixed_valid]
+
+Some text content.
+
+## Reference Definitions (Some Unused, Some Duplicated)
+
+[used1]: https://example.com/used1
+[unused1]: https://example.com/unused1
+[unused2]: https://example.com/unused2
+[duplicate_unused]: https://example.com/duplicate1
+[duplicate_unused]: https://example.com/duplicate2
+[duplicate_used]: https://example.com/first_used
+[duplicate_used]: https://example.com/second_used
+[mixed_valid]: https://example.com/mixed_valid
+[unused3]: https://example.com/unused3


### PR DESCRIPTION
Add comprehensive MD053 rule to detect unused and duplicate link/image reference definitions.

Features:
- Detects unused reference definitions
- Identifies duplicate definitions (first definition wins per CommonMark)
- Supports all reference formats: full [text][label], collapsed [label][], shortcut [label]
- CommonMark compliant label normalization (case-insensitive, whitespace collapse)
- Configurable ignored definitions with sensible defaults (["//"] for comments)
- Performance optimized with pre-compiled regex patterns and HashMap lookups

Implementation:
- Document-wide rule type for comprehensive analysis
- 13 comprehensive unit tests covering all scenarios and edge cases
- Proper integration with configuration system and CLI
- Complete documentation and test sample files
- Code formatting improvements across multiple files

🤖 Generated with [Claude Code](https://claude.ai/code)