### PR TITLE
ci: add rustfmt validation job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,11 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  fmt:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check formatting
+      run: cargo fmt --check


### PR DESCRIPTION
Add a separate fmt job that runs `cargo fmt --check` to ensure all Rust code follows consistent formatting standards.

🤖 Generated with [Claude Code](https://claude.ai/code)