### PR TITLE
feat(workflow): add comprehensive branch naming enforcement and update project guidelines

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,3 +1,3 @@
 1. Commit all unstaged files
-2. Squash commits if needed
-3. Generate the final commit message based on the diff. Follow conventional commit standard.
+2. Squash commits which were not yet published on the remote.
+3. Generate the final commit message based on the diff with the remote branch.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Pre-push hook to enforce branch naming conventions
+# Format: type/issue-number-description
+# Types: feature, fix, docs, chore, refactor
+
+set -e
+
+protected_branches='main|dev'
+branch_pattern='^(feature|fix|docs|chore|refactor)/[0-9]+-[a-z0-9-]+$'
+
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+# Skip check for protected branches
+if [[ "$current_branch" =~ $protected_branches ]]; then
+    exit 0
+fi
+
+# Check if branch name follows convention
+if [[ ! "$current_branch" =~ $branch_pattern ]]; then
+    echo "❌ Branch name '$current_branch' does not follow naming convention"
+    echo ""
+    echo "Required format: type/issue-number-description"
+    echo ""
+    echo "Valid types: feature, fix, docs, chore, refactor"
+    echo "Examples:"
+    echo "  - feature/123-add-md025-rule"
+    echo "  - fix/456-line-ending-detection"
+    echo "  - docs/789-update-contributing-guide"
+    echo "  - chore/101-update-dependencies"
+    echo "  - refactor/202-rule-system-cleanup"
+    echo ""
+    echo "Please rename your branch or create an issue first if needed."
+    exit 1
+fi
+
+echo "✅ Branch name follows convention: $current_branch"
+exit 0

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -25,6 +25,12 @@ jobs:
           
           echo "Checking branch: $branch"
           
+          # Skip protected branches
+          if [[ "$branch" == "main" || "$branch" == "dev" ]]; then
+            echo "✅ Branch '$branch' is a protected branch, skipping validation"
+            exit 0
+          fi
+          
           # Define the pattern for branch naming convention
           # Format: type/issue-number-description
           pattern='^(feature|fix|docs|chore|refactor)/[0-9]+-[a-z0-9-]+$'

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,50 @@
+name: Branch Name Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches-ignore:
+      - main
+      - dev
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    name: Validate branch naming convention
+    
+    steps:
+      - name: Check branch name
+        run: |
+          # Get branch name from different contexts
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            branch="${{ github.head_ref }}"
+          else
+            branch="${{ github.ref_name }}"
+          fi
+          
+          echo "Checking branch: $branch"
+          
+          # Define the pattern for branch naming convention
+          # Format: type/issue-number-description
+          pattern='^(feature|fix|docs|chore|refactor)/[0-9]+-[a-z0-9-]+$'
+          
+          # Check if branch name matches the pattern
+          if [[ ! "$branch" =~ $pattern ]]; then
+            echo "❌ Branch name '$branch' does not follow naming convention"
+            echo ""
+            echo "Required format: type/issue-number-description"
+            echo ""
+            echo "Valid types: feature, fix, docs, chore, refactor"
+            echo "Examples:"
+            echo "  - feature/123-add-md025-rule"
+            echo "  - fix/456-line-ending-detection"
+            echo "  - docs/789-update-contributing-guide"
+            echo "  - chore/101-update-dependencies"
+            echo "  - refactor/202-rule-system-cleanup"
+            echo ""
+            echo "Please rename your branch to follow the convention."
+            exit 1
+          fi
+          
+          echo "✅ Branch name '$branch' follows the naming convention"

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -8,7 +8,7 @@ on:
   issues:
     types: [opened, closed, reopened]
   pull_request:
-    types: [opened, closed, converted_to_draft, ready_for_review, reopened]
+    types: [closed]
 
 jobs:
   manage-issue-status:
@@ -31,54 +31,6 @@ jobs:
               });
             }
 
-  manage-pr-status:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Update PR status labels
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const action = context.payload.action;
-            // Get current labels
-            const currentLabels = pr.labels.map(label => label.name);
-            const statusLabels = currentLabels.filter(label => label.startsWith('status:'));
-            let newLabel = '';
-            switch (action) {
-              case 'opened':
-              case 'reopened':
-                newLabel = pr.draft ? 'status: in-progress' : 'status: review';
-                break;
-              case 'converted_to_draft':
-                newLabel = 'status: in-progress';
-                break;
-              case 'ready_for_review':
-                newLabel = 'status: review';
-                break;
-              case 'closed':
-                newLabel = pr.merged ? 'status: done' : null;
-                break;
-            }
-
-            if (newLabel) {
-              // Remove existing status labels
-              if (statusLabels.length > 0) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  name: statusLabels[0]
-                });
-              }
-              // Add new status label
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: [newLabel]
-              });
-            }
 
   manage-linked-issues:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,3 +275,34 @@ This architecture allows rules like MD013 to work efficiently with raw text whil
 1. **Cover edge cases**: And performance regressions.
 2. **Use `#[should_panic]`**: Where panics are expected.
 3. **Prefer property-based testing**: Use `proptest` or fuzzing where inputs are highly variable.
+
+# Git and Commit Guidelines
+
+## Branch Naming and Workflow
+
+Follow the branch naming conventions defined in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Commit Messages
+
+When working on a branch that follows the naming convention, always include the issue reference in commit messages:
+
+**If the branch name contains an issue number** (e.g., `feature/123-add-rule`), include `fixes #123` in the commit message to automatically link and close the issue when merged.
+
+**Format:**
+```
+Brief description of changes
+
+Longer explanation if needed.
+
+Fixes #123
+```
+
+**Example:**
+```
+Add MD025 single H1 rule implementation
+
+Implements the MD025 rule that ensures documents have only one H1 heading.
+Includes comprehensive tests and documentation.
+
+Fixes #123
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,21 @@ If you'd like to contribute code to QuickMark, please follow these steps:
 
 3. **Create a Branch**
 
+Use descriptive branch names that include the issue number:
+
+**Format:** `type/issue-number-short-description`
+
+- `feature/123-add-md025-rule` - New features
+- `fix/456-line-ending-detection` - Bug fixes
+- `docs/789-update-contributing-guide` - Documentation changes
+- `chore/101-update-dependencies` - Maintenance tasks
+- `refactor/202-rule-system-cleanup` - Code improvements
+
 ```sh
-git checkout -b feature-or-bugfix-description
+git checkout -b feature/123-your-feature-name
 ```
+
+If working on something without an existing issue, please create one first to get an issue number.
 
 4. **Make Changes**
 
@@ -51,9 +63,26 @@ git checkout -b feature-or-bugfix-description
 
 5. **Commit Changes**
 
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) standard for commit messages:
+
+**Format:** `type(scope): description`
+
+Examples:
+- `feat(md025): add single H1 rule implementation`
+- `fix(parser): handle edge case in heading detection`
+- `docs(contributing): update branch naming guidelines`
+- `test(md013): add comprehensive line length tests`
+
+If your commit relates to a specific issue, include `Fixes #123` in the commit body:
+
 ```sh
 git add .
-git commit -m "Description of changes"
+git commit -m "feat(md025): add single H1 rule implementation
+
+Implements the MD025 rule that ensures documents have only one H1 heading.
+Includes comprehensive tests and documentation.
+
+Fixes #123"
 ```
 
 6. **Push to Your Fork**


### PR DESCRIPTION
- Add pre-push Git hook to enforce branch naming conventions locally
- Add GitHub Actions workflow for server-side branch name validation
- Update CONTRIBUTING.md with detailed branch naming and commit message guidelines
- Add commit message standards following Conventional Commits specification
- Update CLAUDE.md with Git workflow guidelines and issue linking instructions
- Remove unnecessary PR status labeling from issue management workflow
- Update publish command documentation for clearer workflow instructions

The branch naming convention enforces type/issue-number-description format with validation for feature, fix, docs, chore, and refactor branch types.