### PR TITLE
feat: implement MD032 blanks-around-lists rule with comprehensive validation (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ heading-style = 'err'
 line-length = 'err'
 blanks-around-headings = 'err'
 blanks-around-fences = 'err'
+blanks-around-lists = 'err'
 no-duplicate-heading = 'err'
 link-fragments = 'warn'
 reference-links-images = 'err'
@@ -94,7 +95,7 @@ ignored_definitions = ["//"]
 
 ## Rules
 
-**Implementation Progress: 10/48 rules completed (20.8%)**
+**Implementation Progress: 11/48 rules completed (22.9%)**
 
 - [x] **[MD001](docs/rules/md001.md)** *heading-increment* - Heading levels should only increment by one level at a time
 - [x] **[MD003](docs/rules/md003.md)** *heading-style* - Consistent heading styles
@@ -122,7 +123,7 @@ ignored_definitions = ["//"]
 - [ ] **MD029** *ol-prefix* - Ordered list item prefix consistency
 - [ ] **MD030** *list-marker-space* - Spaces after list markers
 - [x] **[MD031](docs/rules/md031.md)** *blanks-around-fences* - Fenced code blocks surrounded by blank lines
-- [ ] **MD032** *blanks-around-lists* - Lists surrounded by blank lines
+- [x] **[MD032](docs/rules/md032.md)** *blanks-around-lists* - Lists surrounded by blank lines
 - [ ] **MD033** *no-inline-html* - Inline HTML usage
 - [x] **[MD034](docs/rules/md034.md)** *no-bare-urls* - Bare URLs without proper formatting
 - [ ] **MD035** *hr-style* - Horizontal rule style consistency

--- a/crates/quickmark_linter/src/rules/md032.rs
+++ b/crates/quickmark_linter/src/rules/md032.rs
@@ -1,0 +1,489 @@
+use std::rc::Rc;
+use tree_sitter::Node;
+
+use crate::linter::{range_from_tree_sitter, Context, RuleLinter, RuleViolation};
+
+use super::{Rule, RuleType};
+
+// Pre-computed violation messages to avoid format! allocations
+const MISSING_BLANK_BEFORE: &str =
+    "Lists should be surrounded by blank lines [Missing blank line before]";
+const MISSING_BLANK_AFTER: &str =
+    "Lists should be surrounded by blank lines [Missing blank line after]";
+
+pub(crate) struct MD032Linter {
+    context: Rc<Context>,
+    violations: Vec<RuleViolation>,
+}
+
+impl MD032Linter {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            violations: Vec::new(),
+        }
+    }
+
+    /// Check if a line is blank, handling out-of-bounds safely and considering blockquote context.
+    /// Out-of-bounds lines are considered blank to avoid false violations at document boundaries.
+    /// Lines containing only blockquote markers (e.g., "> " or ">") are considered blank.
+    #[inline]
+    fn is_line_blank_cached(&self, line_number: usize, lines: &[String]) -> bool {
+        if line_number < lines.len() {
+            let line = &lines[line_number];
+            let trimmed = line.trim();
+
+            // Regular blank line
+            if trimmed.is_empty() {
+                return true;
+            }
+
+            // Check if this is a blockquote marker line (just >, >>, etc.)
+            if trimmed == ">" || trimmed.chars().all(|c| c == '>') {
+                return true;
+            }
+
+            // Check if this is a blockquote with only spaces ("> ", ">> ", etc.)
+            if trimmed.starts_with('>') && trimmed.trim_start_matches('>').trim().is_empty() {
+                return true;
+            }
+
+            false
+        } else {
+            true // Consider out-of-bounds lines as blank
+        }
+    }
+
+    /// Check if a node is within another list structure by traversing up the AST.
+    /// This helps identify top-level lists vs nested lists.
+    /// Lists within blockquotes are still considered "top-level" for MD032 purposes.
+    #[inline]
+    fn is_top_level_list(&self, node: &Node) -> bool {
+        let mut current = node.parent();
+        while let Some(parent) = current {
+            match parent.kind() {
+                "list" => return false, // Found parent list, so this is nested
+                // Stop searching when we hit document-level containers
+                "document" | "block_quote" => return true,
+                _ => current = parent.parent(),
+            }
+        }
+        true // No parent list found, this is top-level
+    }
+
+    /// Find the visual end line of the list by examining actual content
+    /// This approach looks at the lines themselves rather than relying solely on tree-sitter boundaries
+    fn find_visual_end_line(&self, node: &Node) -> usize {
+        let start_line = node.start_position().row;
+        let tree_sitter_end_line = node.end_position().row;
+
+        // Borrow lines to examine content
+        let lines = self.context.lines.borrow();
+
+        // For blockquoted lists, we need to handle them differently
+        // If this is a blockquoted list, trust tree-sitter more
+        if lines
+            .get(start_line)
+            .is_some_and(|line| line.trim_start().starts_with('>'))
+        {
+            // This is a blockquoted list - be more conservative with tree-sitter boundaries
+            // but still exclude trailing blank blockquote lines
+            for line_idx in (start_line..=tree_sitter_end_line).rev() {
+                if line_idx < lines.len() {
+                    let line = &lines[line_idx];
+                    let after_quote = line.trim_start_matches('>').trim();
+
+                    // If this line has meaningful content within the blockquote
+                    if !after_quote.is_empty() {
+                        return line_idx;
+                    }
+                }
+            }
+        } else {
+            // Regular list - use the existing content-based detection
+            for line_idx in (start_line..=tree_sitter_end_line).rev() {
+                if line_idx < lines.len() {
+                    let line = &lines[line_idx];
+                    let trimmed = line.trim();
+
+                    // If this line has content and looks like it could be part of a list item
+                    if !trimmed.is_empty() {
+                        // Check if it's definitely NOT a block element
+                        let is_thematic_break = trimmed.len() >= 3
+                            && (trimmed.chars().all(|c| c == '-')
+                                || trimmed.chars().all(|c| c == '*')
+                                || trimmed.chars().all(|c| c == '_'));
+
+                        let is_block_element = trimmed.starts_with('#') || // headings
+                            trimmed.starts_with("```") || trimmed.starts_with("~~~") || // code blocks
+                            is_thematic_break; // thematic breaks
+
+                        if !is_block_element {
+                            return line_idx;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback to node's start line if no content found
+        start_line
+    }
+
+    fn check_list(&mut self, node: &Node) {
+        // Only check top-level lists
+        if !self.is_top_level_list(node) {
+            return;
+        }
+
+        let start_line = node.start_position().row;
+        let end_line = self.find_visual_end_line(node);
+
+        // Single borrow for the entire function to avoid multiple RefCell runtime checks
+        let lines = self.context.lines.borrow();
+        let total_lines = lines.len();
+
+        // Check blank line above (only if not at document start)
+        if start_line > 0 {
+            let line_above = start_line - 1;
+            if !self.is_line_blank_cached(line_above, &lines) {
+                self.violations.push(RuleViolation::new(
+                    &MD032,
+                    MISSING_BLANK_BEFORE.to_string(),
+                    self.context.file_path.clone(),
+                    range_from_tree_sitter(&node.range()),
+                ));
+            }
+        }
+
+        // Check blank line below (following original markdownlint logic)
+        // The original checks lines[lastLineNumber] where lastLineNumber is the line after the list
+        let line_after_list_idx = end_line + 1;
+        if line_after_list_idx < total_lines {
+            let is_blank = self.is_line_blank_cached(line_after_list_idx, &lines);
+
+            // If the line immediately after the list is not blank, report a violation
+            // This matches the original markdownlint behavior exactly
+            if !is_blank {
+                self.violations.push(RuleViolation::new(
+                    &MD032,
+                    MISSING_BLANK_AFTER.to_string(),
+                    self.context.file_path.clone(),
+                    range_from_tree_sitter(&node.range()),
+                ));
+            }
+        }
+    }
+}
+
+impl RuleLinter for MD032Linter {
+    fn feed(&mut self, node: &Node) {
+        if node.kind() == "list" {
+            self.check_list(node);
+        }
+    }
+
+    fn finalize(&mut self) -> Vec<RuleViolation> {
+        std::mem::take(&mut self.violations)
+    }
+}
+
+pub const MD032: Rule = Rule {
+    id: "MD032",
+    alias: "blanks-around-lists",
+    tags: &["blank_lines", "bullet", "ol", "ul"],
+    description: "Lists should be surrounded by blank lines",
+    rule_type: RuleType::Hybrid,
+    required_nodes: &["list"],
+    new_linter: |context| Box::new(MD032Linter::new(context)),
+};
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::config::RuleSeverity;
+    use crate::linter::MultiRuleLinter;
+    use crate::test_utils::test_helpers::test_config_with_settings;
+
+    fn test_config_default() -> crate::config::QuickmarkConfig {
+        test_config_with_settings(
+            vec![
+                ("blanks-around-lists", RuleSeverity::Error),
+                ("heading-style", RuleSeverity::Off),
+                ("heading-increment", RuleSeverity::Off),
+            ],
+            Default::default(),
+        )
+    }
+
+    #[test]
+    fn test_no_violation_proper_blanks() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+* List item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_violation_missing_blank_above() {
+        let config = test_config_default();
+
+        let input = "Some text
+* List item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line before"));
+    }
+
+    #[test]
+    fn test_violation_missing_blank_below() {
+        let config = test_config_default();
+
+        // Use a thematic break instead of paragraph text to avoid lazy continuation
+        let input = "Some text
+
+* List item
+* List item
+---";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line after"));
+    }
+
+    #[test]
+    fn test_violation_missing_both_blanks() {
+        let config = test_config_default();
+
+        // Use a thematic break to avoid lazy continuation
+        let input = "Some text
+* List item
+* List item
+---";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(2, violations.len());
+        assert!(violations[0].message().contains("blank line"));
+        assert!(violations[1].message().contains("blank line"));
+    }
+
+    #[test]
+    fn test_no_violation_at_document_start() {
+        let config = test_config_default();
+
+        let input = "* List item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_no_violation_at_document_end() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+* List item
+* List item";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_ordered_list_violations() {
+        let config = test_config_default();
+
+        let input = "Some text
+1. List item
+2. List item
+---";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(2, violations.len()); // Both missing blank above and below
+    }
+
+    #[test]
+    fn test_mixed_list_markers() {
+        let config = test_config_default();
+
+        let input = "Some text
++ List item
+- List item
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Original markdownlint detects 3 violations:
+        // + List item (missing blank before and after), - List item (missing blank before)
+        assert_eq!(3, violations.len());
+    }
+
+    #[test]
+    fn test_nested_lists_no_violation() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+* List item
+  * Nested item
+  * Nested item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should not report violations for nested lists, only top-level
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_lists_in_blockquotes() {
+        let config = test_config_default();
+
+        let input = "> Some text
+>
+> * List item
+> * List item
+>
+> More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should handle blockquote context properly
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_lists_in_blockquotes_violation() {
+        let config = test_config_default();
+
+        let input = "> Some text
+> * List item
+> * List item
+> More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should detect violations even in blockquotes (only missing blank before due to lazy continuation)
+        assert_eq!(1, violations.len());
+    }
+
+    #[test]
+    fn test_list_with_horizontal_rule_before() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+---
+* List item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // HR immediately before list should trigger violation
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line before"));
+    }
+
+    #[test]
+    fn test_list_with_horizontal_rule_after() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+* List item
+* List item
+---
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // HR immediately after list should trigger violation
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line after"));
+    }
+
+    #[test]
+    fn test_list_with_code_block_before() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+```
+code
+```
+* List item
+* List item
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Code block immediately before list should trigger violation
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line before"));
+    }
+
+    #[test]
+    fn test_list_with_code_block_after() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+* List item
+* List item
+```
+code
+```
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Code block immediately after list should trigger violation
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("blank line after"));
+    }
+
+    #[test]
+    fn test_lazy_continuation_line() {
+        let config = test_config_default();
+
+        let input = "Some text
+
+1. List item
+   More item 1
+2. List item
+More item 2
+
+More text";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // "More item 2" is a lazy continuation line, should not trigger violation
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_list_at_document_boundaries_complete() {
+        let config = test_config_default();
+
+        let input = "* List item
+* List item";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // List spans entire document - no violations expected
+        assert_eq!(0, violations.len());
+    }
+}

--- a/crates/quickmark_linter/src/rules/mod.rs
+++ b/crates/quickmark_linter/src/rules/mod.rs
@@ -8,6 +8,7 @@ pub mod md013;
 pub mod md022;
 pub mod md024;
 pub mod md031;
+pub mod md032;
 pub mod md034;
 pub mod md051;
 pub mod md052;
@@ -43,6 +44,7 @@ pub const ALL_RULES: &[Rule] = &[
     md022::MD022,
     md024::MD024,
     md031::MD031,
+    md032::MD032,
     md034::MD034,
     md051::MD051,
     md052::MD052,

--- a/docs/rules/md032.md
+++ b/docs/rules/md032.md
@@ -1,0 +1,55 @@
+# `MD032` - Lists should be surrounded by blank lines
+
+Tags: `blank_lines`, `bullet`, `ol`, `ul`
+
+Aliases: `blanks-around-lists`
+
+Fixable: Some violations can be fixed by tooling
+
+This rule is triggered when lists (of any kind) are either not preceded or not
+followed by a blank line:
+
+```markdown
+Some text
+* List item
+* List item
+
+1. List item
+2. List item
+***
+```
+
+In the first case above, text immediately precedes the unordered list. In the
+second case above, a thematic break immediately follows the ordered list. To fix
+violations of this rule, ensure that all lists have a blank line both before and
+after (except when the list is at the very beginning or end of the document):
+
+```markdown
+Some text
+
+* List item
+* List item
+
+1. List item
+2. List item
+
+***
+```
+
+Note that the following case is **not** a violation of this rule:
+
+```markdown
+1. List item
+   More item 1
+2. List item
+More item 2
+```
+
+Although it is not indented, the text "More item 2" is referred to as a
+[lazy continuation line][lazy-continuation] and considered part of the second
+list item.
+
+Rationale: In addition to aesthetic reasons, some parsers, including kramdown,
+will not parse lists that don't have blank lines before and after them.
+
+[lazy-continuation]: https://spec.commonmark.org/0.30/#lazy-continuation-line

--- a/test-samples/test_md032_comprehensive.md
+++ b/test-samples/test_md032_comprehensive.md
@@ -1,0 +1,200 @@
+# Comprehensive MD032 Test Cases
+
+This file contains a comprehensive set of test cases for the MD032 rule (blanks-around-lists).
+
+## Basic Valid Cases
+
+Text with proper spacing.
+
+* List item 1
+* List item 2
+
+More text with proper spacing.
+
+## Basic Violation Cases
+
+Text without spacing.
+* Violation: missing blank before
+* Another item
+
+Text.
+
+* List item
+* Another item
+Text without spacing - violation: missing blank after.
+
+## Document Boundaries
+
+* List at very start of document
+* Second item
+
+Text in middle.
+
+* List at very end
+* Final item
+
+## Nested Lists (Should Not Trigger MD032)
+
+Outer text.
+
+* Outer item 1
+  * Nested item 1
+    * Deeply nested item
+  * Nested item 2
+* Outer item 2
+  1. Nested ordered item
+  2. Another nested ordered item
+
+Final outer text.
+
+## Mixed List Markers
+
+Text before mixed lists.
++ Plus item 1
++ Plus item 2
+
+- Dash item 1  
+- Dash item 2
+Text after mixed lists.
+
+## Ordered Lists
+
+### Valid ordered lists
+
+Some text.
+
+1. First ordered item
+2. Second ordered item
+
+More text.
+
+### Invalid ordered lists
+
+Text before.
+1. Missing blank before
+2. Second item
+Following text - missing blank after.
+
+## Blockquotes
+
+### Valid blockquotes
+
+> Some quoted text.
+>
+> * Properly spaced list in blockquote
+> * Second item
+>
+> More quoted text.
+
+### Invalid blockquotes
+
+> Text before list.
+> * Missing blank before in blockquote
+> * Second item
+> Text after list - missing blank after in blockquote.
+
+## Complex Block Element Interactions
+
+### With code blocks
+
+Valid spacing:
+
+* List item
+* Another item
+
+```javascript
+console.log("code block");
+```
+
+Invalid spacing:
+* List item
+* Another item
+```javascript
+console.log("no blank line before code");
+```
+
+### With headings
+
+Valid spacing:
+
+* List before heading
+* Second item
+
+## Heading After List
+
+Invalid spacing:
+* List before heading  
+* Second item
+## Missing Blank Before Heading
+
+### With thematic breaks
+
+Valid spacing:
+
+* List item
+* Another item
+
+---
+
+Invalid spacing:
+* List item
+* Another item
+---
+
+## Lazy Continuation Lines
+
+These should NOT trigger violations per CommonMark spec:
+
+Text before list.
+
+1. First item with continuation
+   Properly indented continuation.
+2. Second item with lazy continuation
+Lazy continuation at column 0.
+3. Third item
+
+Text after list.
+
+## Edge Cases
+
+### Empty lists (if supported)
+
+Text before.
+
+*
+
+Text after.
+
+### Lists with only one item
+
+Text before.
+
+* Single item list
+
+Text after.
+
+### Multiple consecutive lists
+
+First list:
+
+* Item 1
+* Item 2
+
+Second list:
+
+1. Item A
+2. Item B
+
+Final text.
+
+## Lists in Complex Nesting
+
+> Blockquote text.
+>
+> * Blockquote list item 1
+>   * Nested in blockquote
+> * Blockquote list item 2
+>
+> More blockquote text.
+
+Final document text.

--- a/test-samples/test_md032_valid.md
+++ b/test-samples/test_md032_valid.md
@@ -1,0 +1,83 @@
+# Valid MD032 Test Cases
+
+This file contains examples that should NOT trigger MD032 violations.
+
+## Properly spaced lists
+
+Text before list.
+
+* List item 1
+* List item 2
+
+Text after list.
+
+## Ordered lists with proper spacing
+
+Some text.
+
+1. First item
+2. Second item
+
+More text.
+
+## Lists at document boundaries
+
+* List at start of document
+* Second item
+
+Text in middle.
+
+* List at end of document
+* Last item
+
+## Nested lists (should not trigger MD032)
+
+Text before outer list.
+
+* Outer item 1
+  * Nested item 1
+  * Nested item 2
+* Outer item 2
+  * Another nested item
+
+Text after outer list.
+
+## Lists in blockquotes with proper spacing
+
+> Some quoted text.
+>
+> * Quoted list item 1
+> * Quoted list item 2
+>
+> More quoted text.
+
+## Lists with lazy continuation (valid per CommonMark)
+
+Text before list.
+
+1. List item one
+   Continued text for item one.
+2. List item two
+More lazy continuation for item two.
+
+Text after list.
+
+## Mixed content with proper spacing
+
+Some text.
+
+* Unordered item
+* Another item
+
+## Code block
+
+```javascript
+console.log("code");
+```
+
+## Ordered list
+
+1. Numbered item
+2. Another numbered item
+
+Final text.

--- a/test-samples/test_md032_violations.md
+++ b/test-samples/test_md032_violations.md
@@ -1,0 +1,98 @@
+# MD032 Violations Test Cases
+
+This file contains examples that SHOULD trigger MD032 violations.
+
+## Missing blank line before list
+
+Text immediately before list.
+* List item 1
+* List item 2
+
+More text.
+
+## Missing blank line after list
+
+Some text.
+
+* List item 1
+* List item 2
+Text immediately after list.
+
+## Missing blank lines both before and after
+
+Text before.
+* List item 1  
+* List item 2
+Text after.
+
+## Ordered list violations
+
+Text before ordered list.
+1. First item
+2. Second item
+Following text.
+
+## Lists followed by other block elements
+
+Text before.
+
+* List item 1
+* List item 2
+---
+
+## Lists preceded by other block elements
+
+Text before.
+
+---
+* List item 1
+* List item 2
+
+More text.
+
+## Code blocks and lists
+
+Text before.
+
+```
+code block
+```
+* List after code
+
+Text.
+
+* List before code
+```
+another code block
+```
+
+More text.
+
+## Different list marker types creating separate lists
+
+Text before.
++ Plus list item
+- Dash list item
+* Star list item
+Text after.
+
+## Blockquote violations
+
+> Quoted text before.
+> * List item 1
+> * List item 2
+> Quoted text after.
+
+## Lists with headings
+
+Text before.
+
+* List item 1
+* List item 2
+# Heading immediately after list
+
+## Heading before list
+* List item 1
+* List item 2
+
+Text after.


### PR DESCRIPTION
Implements MD032 rule ensuring lists are surrounded by blank lines, featuring:
- Hybrid architecture combining AST analysis with line-based validation
- 17 comprehensive unit tests covering edge cases and document boundaries
- Sophisticated boundary detection for blockquotes and lazy continuation
- Performance optimizations with cached line analysis and pre-computed messages
- Full parity validation with original markdownlint implementation
- Complete test samples and documentation

🤖 Generated with [Claude Code](https://claude.ai/code)