### PR TITLE
feat: implement QUICKMARK_CONFIG environment variable support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "anyhow",
  "quickmark_linter",
  "serde",
+ "tempfile",
  "toml",
 ]
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,29 @@ qmark /path/to/file.md
 
 ### Configuration
 
-Quickmark looks up for `quickmark.toml` configuration file in the current working directory. If the file was not found, the default is used.
+QuickMark looks for configuration in the following order:
+
+1. **Environment Variable**: If `QUICKMARK_CONFIG` environment variable is set, it uses the config file at the specified path
+2. **Local Config**: If not found, it looks for `quickmark.toml` in the current working directory  
+3. **Default**: If neither is found, default configuration is used
+
+#### Using QUICKMARK_CONFIG Environment Variable
+
+You can specify a custom configuration file location using the `QUICKMARK_CONFIG` environment variable:
+
+```shell
+# Set config file path
+export QUICKMARK_CONFIG="/path/to/your/custom-config.toml"
+qmark file.md
+
+# Or use it inline
+QUICKMARK_CONFIG="/path/to/custom-config.toml" qmark file.md
+```
+
+This is especially useful for:
+- Shared configurations across multiple projects
+- CI/CD pipelines with centralized configs
+- Different config files for different environments
 
 Below is a full configuration with default values:
 

--- a/crates/quickmark/src/main.rs
+++ b/crates/quickmark/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::Parser;
-use quickmark_config::config_in_path_or_default;
+use quickmark_config::config_from_env_path_or_default;
 use quickmark_linter::config::{QuickmarkConfig, RuleSeverity};
 use quickmark_linter::linter::{MultiRuleLinter, RuleViolation};
 use std::cmp::min;
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
         .context(format!("Can't read file {}", &file_path.to_string_lossy()))?;
 
     let pwd = env::current_dir()?;
-    let config = config_in_path_or_default(&pwd)?;
+    let config = config_from_env_path_or_default(&pwd)?;
 
     let mut linter = MultiRuleLinter::new_for_document(file_path, config.clone(), &file_content);
 

--- a/crates/quickmark_config/Cargo.toml
+++ b/crates/quickmark_config/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2021"
 anyhow = "1.0.86"
 quickmark_linter = { path = "../quickmark_linter" }
 serde = { version = "1.0.203", features = ["derive"] }
-toml = "0.8.14" 
+toml = "0.8.14"
+
+[dev-dependencies]
+tempfile = "3.8" 


### PR DESCRIPTION
Adds support for QUICKMARK_CONFIG environment variable to specify custom configuration file paths. The linter now follows configuration precedence:
1. QUICKMARK_CONFIG environment variable path
2. Local quickmark.toml in current directory
3. Default configuration

Key changes:
- New config_from_env_path_or_default() function in quickmark_config crate
- Environment variable takes precedence over local config files
- Graceful error handling: invalid paths show warnings but continue with defaults
- Comprehensive integration and unit test coverage
- Updated README with usage examples and documentation

This enables shared configurations across projects, centralized CI/CD configs, and environment-specific configuration files.

🤖 Generated with [Claude Code](https://claude.ai/code)