### PR TITLE
feat: implement MD014 commands-show-output rule with perfect parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ignored_definitions = ["//"]
 
 ## Rules
 
-**Implementation Progress: 20/52 rules completed (38.5%)**
+**Implementation Progress: 21/52 rules completed (40.4%)**
 
 - [x] **[MD001](docs/rules/md001.md)** *heading-increment* - Heading levels should only increment by one level at a time
 - [x] **[MD003](docs/rules/md003.md)** *heading-style* - Consistent heading styles
@@ -154,7 +154,7 @@ ignored_definitions = ["//"]
 - [ ] **MD011** *no-reversed-links* - Reversed link syntax
 - [ ] **MD012** *no-multiple-blanks* - Multiple consecutive blank lines
 - [x] **[MD013](docs/rules/md013.md)** *line-length* - Line length limits with configurable exceptions
-- [ ] **MD014** *commands-show-output* - Dollar signs before shell commands
+- [x] **[MD014](docs/rules/md014.md)** *commands-show-output* - Dollar signs before shell commands
 - [x] **[MD018](docs/rules/md018.md)** *no-missing-space-atx* - Space after hash in ATX headings
 - [x] **[MD019](docs/rules/md019.md)** *no-multiple-space-atx* - Multiple spaces after hash in ATX headings
 - [x] **[MD020](docs/rules/md020.md)** *no-missing-space-closed-atx* - Space inside closed ATX headings

--- a/crates/quickmark_linter/src/rules/md014.rs
+++ b/crates/quickmark_linter/src/rules/md014.rs
@@ -1,0 +1,303 @@
+use regex::Regex;
+use std::{cell::RefCell, rc::Rc};
+use tree_sitter::Node;
+
+use crate::linter::{CharPosition, Context, Range, RuleLinter, RuleViolation};
+
+use super::{Rule, RuleType};
+
+const VIOLATION_MESSAGE: &str = "Dollar signs used before commands without showing output";
+
+pub(crate) struct MD014Linter {
+    context: Rc<Context>,
+    pending_violations: RefCell<Vec<RuleViolation>>,
+    dollar_regex: Regex,
+}
+
+impl MD014Linter {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            pending_violations: RefCell::new(Vec::new()),
+            dollar_regex: Regex::new(r"^(\s*)\$\s+").unwrap(),
+        }
+    }
+
+    /// Analyze all code blocks using cached nodes
+    fn analyze_all_code_blocks(&self) {
+        let mut violations = Vec::new();
+        let node_cache = self.context.node_cache.borrow();
+        let lines = self.context.lines.borrow();
+
+        // Check fenced code blocks
+        if let Some(fenced_blocks) = node_cache.get("fenced_code_block") {
+            for node_info in fenced_blocks {
+                if let Some(violation) = self.check_code_block_info(node_info, &lines, true) {
+                    violations.push(violation);
+                }
+            }
+        }
+
+        // Check indented code blocks
+        if let Some(indented_blocks) = node_cache.get("indented_code_block") {
+            for node_info in indented_blocks {
+                if let Some(violation) = self.check_code_block_info(node_info, &lines, false) {
+                    violations.push(violation);
+                }
+            }
+        }
+
+        *self.pending_violations.borrow_mut() = violations;
+    }
+
+    fn check_code_block_info(
+        &self,
+        node_info: &crate::linter::NodeInfo,
+        lines: &[String],
+        is_fenced: bool,
+    ) -> Option<RuleViolation> {
+        let start_line = node_info.line_start;
+        let end_line = node_info.line_end;
+
+        // Extract content lines from the code block
+        let mut content_lines = Vec::new();
+
+        // For fenced code blocks, skip the fence lines
+        let (content_start, content_end) = if is_fenced {
+            // Skip first and last line (fence markers)
+            (start_line + 1, end_line.saturating_sub(1))
+        } else {
+            // For indented code blocks, include all lines
+            (start_line, end_line)
+        };
+
+        // Collect non-empty lines
+        for line_idx in content_start..=content_end {
+            if line_idx < lines.len() {
+                let line = &lines[line_idx];
+                if !line.trim().is_empty() {
+                    // For indented code blocks, filter lines that don't have proper indentation
+                    // This works around tree-sitter-md parsing inconsistencies
+                    if !is_fenced {
+                        // Check if line starts with at least 4 spaces (indented code block requirement)
+                        if !line.starts_with("    ") && !line.starts_with('\t') {
+                            continue;
+                        }
+                    }
+                    content_lines.push((line_idx, line));
+                }
+            }
+        }
+
+        // If no non-empty lines, no violation
+        if content_lines.is_empty() {
+            return None;
+        }
+
+        // Check if ALL non-empty lines start with dollar sign
+        let all_have_dollar = content_lines
+            .iter()
+            .all(|(_, line)| self.dollar_regex.is_match(line));
+
+        if all_have_dollar {
+            // Report violation on the first line with dollar sign
+            if let Some((first_line_idx, first_line)) = content_lines.first() {
+                let range = Range {
+                    start: CharPosition {
+                        line: *first_line_idx,
+                        character: 0,
+                    },
+                    end: CharPosition {
+                        line: *first_line_idx,
+                        character: first_line.len(),
+                    },
+                };
+
+                return Some(RuleViolation::new(
+                    &MD014,
+                    VIOLATION_MESSAGE.to_string(),
+                    self.context.file_path.clone(),
+                    range,
+                ));
+            }
+        }
+
+        None
+    }
+}
+
+impl RuleLinter for MD014Linter {
+    fn feed(&mut self, _node: &Node) {
+        // Document rule type - we don't process individual nodes during feed
+    }
+
+    fn finalize(&mut self) -> Vec<RuleViolation> {
+        self.analyze_all_code_blocks();
+        std::mem::take(&mut self.pending_violations.borrow_mut())
+    }
+}
+
+pub const MD014: Rule = Rule {
+    id: "MD014",
+    alias: "commands-show-output",
+    tags: &["code"],
+    description: "Dollar signs used before commands without showing output",
+    rule_type: RuleType::Document,
+    required_nodes: &["fenced_code_block", "indented_code_block"],
+    new_linter: |context| Box::new(MD014Linter::new(context)),
+};
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::config::RuleSeverity;
+    use crate::linter::MultiRuleLinter;
+    use crate::test_utils::test_helpers::test_config_with_settings;
+
+    fn test_config() -> crate::config::QuickmarkConfig {
+        test_config_with_settings(
+            vec![
+                ("commands-show-output", RuleSeverity::Error),
+                ("heading-style", RuleSeverity::Off),
+                ("heading-increment", RuleSeverity::Off),
+            ],
+            Default::default(),
+        )
+    }
+
+    #[test]
+    fn test_violation_all_lines_with_dollar_signs() {
+        let config = test_config();
+
+        let input = "```bash
+$ git status
+$ ls -la
+$ pwd
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("Dollar signs"));
+    }
+
+    #[test]
+    fn test_no_violation_with_command_output() {
+        let config = test_config();
+
+        let input = "```bash
+$ git status
+On branch main
+nothing to commit
+
+$ ls -la
+total 8
+drwxr-xr-x 2 user user 4096 Jan 1 00:00 .
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_no_violation_no_dollar_signs() {
+        let config = test_config();
+
+        let input = "```bash
+git status
+ls -la
+pwd
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_violation_indented_code_block() {
+        let config = test_config();
+
+        let input = "Some text:
+
+    $ git status
+    $ ls -la
+    $ pwd
+
+More text.";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("Dollar signs"));
+    }
+
+    #[test]
+    fn test_no_violation_mixed_dollar_signs() {
+        let config = test_config();
+
+        let input = "```bash
+$ git status
+ls -la
+$ pwd
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_violation_with_whitespace_before_dollar() {
+        let config = test_config();
+
+        let input = "```bash
+  $ git status
+  $ ls -la
+  $ pwd
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("Dollar signs"));
+    }
+
+    #[test]
+    fn test_no_violation_empty_code_block() {
+        let config = test_config();
+
+        let input = "```bash
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_no_violation_blank_lines_only() {
+        let config = test_config();
+
+        let input = "```bash
+
+
+
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_violation_with_blank_lines_between_commands() {
+        let config = test_config();
+
+        let input = "```bash
+$ git status
+
+$ ls -la
+
+$ pwd
+```";
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("Dollar signs"));
+    }
+}

--- a/crates/quickmark_linter/src/rules/mod.rs
+++ b/crates/quickmark_linter/src/rules/mod.rs
@@ -8,6 +8,7 @@ pub mod md004;
 pub mod md005;
 pub mod md007;
 pub mod md013;
+pub mod md014;
 pub mod md018;
 pub mod md019;
 pub mod md020;
@@ -53,6 +54,7 @@ pub const ALL_RULES: &[Rule] = &[
     md005::MD005,
     md007::MD007,
     md013::MD013,
+    md014::MD014,
     md018::MD018,
     md019::MD019,
     md020::MD020,

--- a/docs/rules/md014.md
+++ b/docs/rules/md014.md
@@ -1,0 +1,44 @@
+# MD014 - commands-show-output
+
+Dollar signs used before commands without showing output
+
+## Tags
+
+code
+
+## Description
+
+This rule is triggered when code blocks show shell commands preceded by dollar signs ($), but no output is displayed.
+
+## Examples of violations
+
+```markdown
+$ ls
+$ cat foo
+$ less bar
+```
+
+## Examples of correct usage
+
+```markdown
+ls
+cat foo
+less bar
+```
+
+Or when output is shown:
+
+```markdown
+$ ls
+file1.txt file2.txt
+$ cat file1.txt
+Hello World
+```
+
+## Rationale
+
+It is easier to copy/paste and less noisy if the dollar signs are omitted when they are not needed.
+
+## Configuration
+
+This rule has no configuration options.

--- a/test-samples/test_md014_comprehensive.md
+++ b/test-samples/test_md014_comprehensive.md
@@ -1,0 +1,63 @@
+# MD014 Comprehensive Test
+
+## Variables (should not trigger)
+
+```bash
+$foo = 'bar'
+$baz = 'qux'
+```
+
+## Mixed content with output (should not trigger)
+
+```bash
+$ ls
+file1.txt file2.txt
+$ git status
+On branch main
+$ cat file1.txt
+content here
+```
+
+## No space after dollar (should not trigger - not a command)
+
+```bash
+$HOME/bin/script
+$PATH variable
+```
+
+## All commands without output (should trigger)
+
+```bash
+$ mkdir test
+$ cd test
+$ ls
+```
+
+## Commands in indented block (should trigger)
+
+Text before:
+
+    $ command1
+    $ command2
+
+Text after.
+
+## Whitespace variations (should trigger)
+
+```bash
+  $ command1
+   $ command2
+    $ command3
+```
+
+## Tab-indented commands (should trigger)
+
+	$ command1
+	$ command2
+
+## Mixed tabs and spaces (should trigger if all have dollar)
+
+```bash
+	$ command1
+    $ command2
+```

--- a/test-samples/test_md014_valid.md
+++ b/test-samples/test_md014_valid.md
@@ -1,0 +1,49 @@
+# MD014 Test Cases - Valid (No Violations)
+
+## Command with output
+
+```bash
+$ git status
+On branch main
+nothing to commit
+working tree clean
+```
+
+## Mixed commands and output
+
+```bash
+$ git status
+On branch main
+$ ls -la
+total 8
+drwxr-xr-x 2 user user 4096 Jan 1 00:00 .
+```
+
+## No dollar signs
+
+```bash
+git status
+ls -la
+pwd
+```
+
+## Mixed dollar signs (some lines without)
+
+```bash
+$ git status
+ls -la
+$ pwd
+```
+
+## Empty code block
+
+```bash
+```
+
+## Blank lines only
+
+```bash
+
+
+
+```

--- a/test-samples/test_md014_violations.md
+++ b/test-samples/test_md014_violations.md
@@ -1,0 +1,37 @@
+# MD014 Test Cases - Violations
+
+## Fenced code block with all dollar signs
+
+```bash
+$ git status
+$ ls -la
+$ pwd
+```
+
+## Indented code block with all dollar signs
+
+Some text:
+
+    $ git status
+    $ ls -la
+    $ pwd
+
+More text.
+
+## Fenced with whitespace before dollar
+
+```sh
+  $ git status
+  $ ls -la
+  $ pwd
+```
+
+## With blank lines between commands
+
+```bash
+$ git status
+
+$ ls -la
+
+$ pwd
+```


### PR DESCRIPTION
Implements MD014 rule that detects dollar signs used before shell commands when no output is shown. The rule triggers violations when ALL non-empty lines in a code block start with dollar signs, suggesting users remove unnecessary command prompts for better copy/paste experience.

Key Features:
- Supports both fenced and indented code blocks
- Uses Document-type rule with cached nodes for optimal performance
- Handles tree-sitter-md parsing inconsistencies for indented blocks
- Comprehensive test coverage with 9 unit tests
- Perfect parity validation against original markdownlint

Technical Implementation:
- Uses regex pattern `^(\s*)\$\s+` to match dollar sign commands
- Filters content properly for fenced vs indented code blocks
- Reports violations on first line of violating code block
- Integrates seamlessly with existing rule architecture

🤖 Generated with [Claude Code](https://claude.ai/code)