### PR TITLE
feat: implement MD058 blanks-around-tables rule with perfect parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ reference-links-images = 'err'
 link-image-reference-definitions = 'err'
 table-pipe-style = 'err'
 table-column-count = 'err'
+blanks-around-tables = 'err'
 
 # see a specific rule's doc for details of configuration
 [linters.settings.heading-style]
@@ -176,7 +177,7 @@ style = 'consistent'
 
 ## Rules
 
-**Implementation Progress: 48/52 rules completed (92.3%)**
+**Implementation Progress: 49/52 rules completed (94.2%)**
 
 - [x] **[MD001](docs/rules/md001.md)** *heading-increment* - Heading levels should only increment by one level at a time
 - [x] **[MD003](docs/rules/md003.md)** *heading-style* - Consistent heading styles
@@ -228,5 +229,5 @@ style = 'consistent'
 - [x] **[MD054](docs/rules/MD054.md)** *link-image-style* - Link and image style
 - [x] **[MD055](docs/rules/md055.md)** *table-pipe-style* - Table pipe style
 - [x] **[MD056](docs/rules/md056.md)** *table-column-count* - Table column count
-- [ ] **MD058** *blanks-around-tables* - Tables should be surrounded by blank lines
+- [x] **[MD058](docs/rules/md058.md)** *blanks-around-tables* - Tables should be surrounded by blank lines
 - [ ] **MD059** *descriptive-link-text* - Link text should be descriptive

--- a/crates/quickmark_linter/src/rules/md058.rs
+++ b/crates/quickmark_linter/src/rules/md058.rs
@@ -1,0 +1,278 @@
+use std::rc::Rc;
+
+use tree_sitter::Node;
+
+use crate::{
+    linter::{range_from_tree_sitter, Context, RuleLinter, RuleViolation},
+    rules::{Rule, RuleType},
+};
+
+/// MD058 - Tables should be surrounded by blank lines
+///
+/// This rule checks that tables have blank lines before and after them,
+/// except when the table is at the very beginning or end of the document.
+pub(crate) struct MD058Linter {
+    context: Rc<Context>,
+    violations: Vec<RuleViolation>,
+}
+
+impl MD058Linter {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            violations: Vec::new(),
+        }
+    }
+
+    fn check_table_blanks(&mut self, table_node: &Node) {
+        let start_line = table_node.start_position().row;
+        let lines = self.context.lines.borrow();
+
+        // Find the actual last row of the table.
+        // tree-sitter can sometimes identify nodes as table rows even if they are not
+        // part of the table's syntax (e.g., surrounding text).
+        // We filter for children that are actual table components and contain a pipe character.
+        let mut cursor = table_node.walk();
+        let Some(last_row) = table_node
+            .children(&mut cursor)
+            .filter(|child| {
+                matches!(
+                    child.kind(),
+                    "pipe_table_header" | "pipe_table_row" | "pipe_table_delimiter_row"
+                )
+            })
+            .filter(|row| {
+                let row_line = row.start_position().row;
+                lines.get(row_line).is_some_and(|l| l.contains('|'))
+            })
+            .last()
+        else {
+            return; // No valid rows in table, nothing to check.
+        };
+
+        let actual_end_line = last_row.end_position().row;
+
+        // Check for a blank line above the table if it's not at the document start.
+        if start_line > 0 {
+            // A blank line is required only if there is non-blank content somewhere above the table.
+            let has_content_above = (0..start_line).any(|i| !lines[i].trim().is_empty());
+
+            if has_content_above && !lines[start_line - 1].trim().is_empty() {
+                self.violations.push(RuleViolation::new(
+                    &MD058,
+                    format!("{} [Above]", MD058.description),
+                    self.context.file_path.clone(),
+                    range_from_tree_sitter(&table_node.range()),
+                ));
+            }
+        }
+
+        // Check for a blank line below the table if it's not at the document end.
+        if actual_end_line + 1 < lines.len() {
+            // A blank line is required only if there is non-blank content somewhere below the table.
+            let has_content_below =
+                ((actual_end_line + 1)..lines.len()).any(|i| !lines[i].trim().is_empty());
+
+            if has_content_below && !lines[actual_end_line + 1].trim().is_empty() {
+                self.violations.push(RuleViolation::new(
+                    &MD058,
+                    format!("{} [Below]", MD058.description),
+                    self.context.file_path.clone(),
+                    range_from_tree_sitter(&table_node.range()),
+                ));
+            }
+        }
+    }
+}
+
+impl RuleLinter for MD058Linter {
+    fn feed(&mut self, node: &Node) {
+        if node.kind() == "pipe_table" {
+            self.check_table_blanks(node);
+        }
+    }
+
+    fn finalize(&mut self) -> Vec<RuleViolation> {
+        std::mem::take(&mut self.violations)
+    }
+}
+
+pub const MD058: Rule = Rule {
+    id: "MD058",
+    alias: "blanks-around-tables",
+    tags: &["table", "blank_lines"],
+    description: "Tables should be surrounded by blank lines",
+    rule_type: RuleType::Token,
+    required_nodes: &["pipe_table"],
+    new_linter: |context| Box::new(MD058Linter::new(context)),
+};
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use crate::{
+        config::RuleSeverity, linter::MultiRuleLinter,
+        test_utils::test_helpers::test_config_with_rules,
+    };
+
+    fn test_config() -> crate::config::QuickmarkConfig {
+        test_config_with_rules(vec![("blanks-around-tables", RuleSeverity::Error)])
+    }
+
+    #[test]
+    fn test_table_with_proper_blank_lines() {
+        let input = r#"Some text
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+More text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_table_missing_blank_line_above() {
+        let input = r#"Some text
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+More text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("[Above]"));
+    }
+
+    #[test]
+    fn test_table_missing_blank_line_below() {
+        let input = r#"Some text
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+More text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(1, violations.len());
+        assert!(violations[0].message().contains("[Below]"));
+    }
+
+    #[test]
+    fn test_table_missing_both_blank_lines() {
+        let input = r#"Some text
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+More text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(2, violations.len());
+        assert!(violations[0].message().contains("[Above]"));
+        assert!(violations[1].message().contains("[Below]"));
+    }
+
+    #[test]
+    fn test_table_at_start_of_document() {
+        let input = r#"| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+More text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should not violate - no content above to require blank line
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_table_at_end_of_document() {
+        let input = r#"Some text
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should not violate - no content below to require blank line
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_table_alone_in_document() {
+        let input = r#"| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should not violate - no content above or below
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_multiple_tables_proper_spacing() {
+        let input = r#"Some text
+
+| Table 1 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+
+Text between tables
+
+| Table 2 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+
+Final text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(0, violations.len());
+    }
+
+    #[test]
+    fn test_multiple_tables_improper_spacing() {
+        let input = r#"Some text
+| Table 1 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+Text between tables
+| Table 2 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+Final text"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        assert_eq!(4, violations.len()); // 2 tables × 2 violations each (above and below)
+    }
+
+    #[test]
+    fn test_table_with_only_blank_lines_above_and_below() {
+        let input = r#"
+
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+
+"#;
+        let config = test_config();
+        let mut linter = MultiRuleLinter::new_for_document(PathBuf::from("test.md"), config, input);
+        let violations = linter.analyze();
+        // Should not violate - no actual content above or below
+        assert_eq!(0, violations.len());
+    }
+}

--- a/crates/quickmark_linter/src/rules/mod.rs
+++ b/crates/quickmark_linter/src/rules/mod.rs
@@ -50,6 +50,7 @@ pub mod md053;
 pub mod md054;
 pub mod md055;
 pub mod md056;
+pub mod md058;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuleType {
@@ -123,4 +124,5 @@ pub const ALL_RULES: &[Rule] = &[
     md054::MD054,
     md055::MD055,
     md056::MD056,
+    md058::MD058,
 ];

--- a/docs/rules/md058.md
+++ b/docs/rules/md058.md
@@ -1,0 +1,83 @@
+# MD058 - Tables should be surrounded by blank lines
+
+**Tags:** table, blank_lines  
+**Aliases:** blanks-around-tables
+
+## Description
+
+This rule checks that tables are surrounded by blank lines above and below them.
+
+## Rationale
+
+"In addition to aesthetic reasons, some parsers will incorrectly parse tables that don't have blank lines before and after them."
+
+Ensuring tables have proper spacing improves:
+- Parser compatibility across different Markdown processors
+- Document readability and structure
+- Consistent formatting standards
+
+## Example of a Violation
+
+```markdown
+Some text
+| Header | Header |
+| ------ | ------ |
+| Cell   | Cell   |
+> Blockquote
+```
+
+## Example of Correct Formatting
+
+```markdown
+Some text
+
+| Header | Header |
+| ------ | ------ |
+| Cell   | Cell   |
+
+> Blockquote
+```
+
+## Key Points
+
+- Tables must have a blank line above them (unless at the start of the document)
+- Tables must have a blank line below them (unless at the end of the document)
+- Text immediately following a table can be considered part of the table by some parsers
+- This rule improves compatibility with various Markdown parsers
+
+## Configuration
+
+This rule has no specific configuration options.
+
+## Fix
+
+To fix this issue:
+
+1. **Add a blank line above the table** if there is content before it
+2. **Add a blank line below the table** if there is content after it
+
+Example fix:
+
+```markdown
+<!-- Before (violation) -->
+Text above table.
+| Header | Value |
+| ------ | ----- |
+| Data   | Info  |
+Text below table.
+
+<!-- After (corrected) -->
+Text above table.
+
+| Header | Value |
+| ------ | ----- |
+| Data   | Info  |
+
+Text below table.
+```
+
+## Related Rules
+
+- [MD022 - Headings should be surrounded by blank lines](md022.md): Similar spacing requirements for headings
+- [MD056 - Table column count](md056.md): Ensures consistent column counts in tables
+- [MD055 - Table pipe style](md055.md): Enforces consistent pipe usage in tables

--- a/test-samples/quickmark-md058-only.toml
+++ b/test-samples/quickmark-md058-only.toml
@@ -1,0 +1,22 @@
+[linters]
+
+[linters.severity]
+# Enable only MD058 (blanks-around-tables)
+"blanks-around-tables" = "err"
+
+# Disable all other rules
+"heading-increment" = "off"
+"heading-style" = "off"
+"list-style" = "off"
+"list-indent" = "off"
+"trailing-spaces" = "off"
+"hard-tabs" = "off"
+"multiple-blank-lines" = "off"
+"line-length" = "off"
+"blanks-around-headings" = "off"
+"single-title" = "off"
+"multiple-headings" = "off"
+"hr-style" = "off"
+"inline-html" = "off"
+"table-pipe-style" = "off"
+"table-column-count" = "off"

--- a/test-samples/test_md058_comprehensive.md
+++ b/test-samples/test_md058_comprehensive.md
@@ -1,0 +1,196 @@
+# MD058 Comprehensive Test Cases
+
+This file contains a comprehensive set of test cases for the MD058 rule (blanks-around-tables).
+
+## 1. Valid Cases
+
+### 1.1 Proper spacing around table
+
+Some text before.
+
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   |
+| Row 2    | Data     | More     |
+
+Some text after.
+
+### 1.2 Table at document start
+
+| Start | Document | Table |
+| ----- | -------- | ----- |
+| Data  | Goes     | Here  |
+
+Content after start table.
+
+### 1.3 Table at document end
+
+Content before end table.
+
+| End | Document | Table |
+| --- | -------- | ----- |
+| End | Data     | Here  |
+
+### 1.4 Single table in document
+
+| Alone | Table |
+| ----- | ----- |
+| Data  | Here  |
+
+### 1.5 Multiple properly spaced tables
+
+First section.
+
+| First | Table |
+| ----- | ----- |
+| Data  | One   |
+
+Middle section content here.
+
+| Second | Table |
+| ------ | ----- |
+| Data   | Two   |
+
+Final section.
+
+## 2. Violation Cases
+
+### 2.1 Missing blank line above
+Text directly above.
+| No | Above | Blank |
+| -- | ----- | ----- |
+| Missing | Space | Above |
+
+Proper space below.
+
+### 2.2 Missing blank line below
+
+Proper space above.
+
+| No | Below | Blank |
+| -- | ----- | ----- |
+| Missing | Space | Below |
+Text directly below.
+
+### 2.3 Missing both blank lines
+Text above.
+| No | Blanks | Around |
+| -- | ------ | ------ |
+| Missing | Both | Sides |
+Text below.
+
+### 2.4 Multiple violations
+
+First text.
+| First | Violation |
+| ----- | --------- |
+| Missing | Above |
+
+Middle text.
+
+| Second | Violation |
+| ------ | --------- |
+| Missing | Below |
+Following text.
+
+### 2.5 Complex table structures
+
+#### Missing above spacing
+Previous content.
+| Complex | Table | With | Many | Columns |
+| ------- | ----- | ---- | ---- | ------- |
+| Row 1   | Data  | More | Info | Here    |
+| Row 2   | Even  | More | Data | Points  |
+
+Proper spacing below.
+
+#### Missing below spacing
+
+Proper spacing above.
+
+| Another | Complex | Table |
+| ------- | ------- | ----- |
+| Data    | Values  | Items |
+| More    | Rows    | Data  |
+Immediate text following.
+
+## 3. Edge Cases
+
+### 3.1 Table with different column counts (should still check spacing)
+
+Proper spacing above.
+
+| Header |
+| ------ |
+| Single |
+
+Proper spacing below.
+
+### 3.2 Tables in lists
+
+1. First item
+
+   | Table | In | List |
+   | ----- | -- | ---- |
+   | Data  | In | Item |
+
+2. Second item
+
+### 3.3 Tables in blockquotes
+
+> Quote with table:
+>
+> | Quote | Table |
+> | ----- | ----- |
+> | Data  | Here  |
+>
+> More quote text.
+
+### 3.4 Adjacent violation cases
+Text before first table.
+| First | Table |
+| ----- | ----- |
+| Data  | One   |
+| Second | Table |
+| ------ | ----- |
+| Data   | Two   |
+Text after second table.
+
+## 4. Mixed valid and invalid
+
+### Valid table 1
+
+Content before.
+
+| Valid | Table | One |
+| ----- | ----- | --- |
+| Good  | Space | All |
+
+Content after.
+
+### Invalid table 1
+Direct text above.
+| Invalid | Table | One |
+| ------- | ----- | --- |
+| Bad | Spacing | Above |
+
+Good spacing below.
+
+### Valid table 2
+
+Good spacing above.
+
+| Valid | Table | Two |
+| ----- | ----- | --- |
+| Good  | Space | All |
+
+Good spacing below.
+
+### Invalid table 2
+
+Good spacing above.
+
+| Invalid | Table | Two |
+| ------- | ----- | --- |
+| Bad | Spacing | Below |
+Direct text below.

--- a/test-samples/test_md058_valid.md
+++ b/test-samples/test_md058_valid.md
@@ -1,0 +1,77 @@
+# MD058 Test - Valid Cases
+
+## Table with proper blank lines above and below
+
+Some text before the table.
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+Some text after the table.
+
+## Table at the start of document
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+Text after table.
+
+## Table at the end of document
+
+Some text before.
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+## Table alone in document
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+## Multiple tables with proper spacing
+
+First paragraph.
+
+| Table 1 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+
+Text between tables.
+
+| Table 2 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+
+Final paragraph.
+
+## Table with only blank lines above and below (no content)
+
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+
+## Single-row table with proper spacing
+
+Some content.
+
+| Single | Row |
+
+More content.
+
+## Table with complex content
+
+Before table content.
+
+| Complex | Table | Example |
+| ------- | ----- | ------- |
+| Data    | More  | Items   |
+| Row 2   | Data  | Here    |
+| Row 3   | Even  | More    |
+
+After table content.

--- a/test-samples/test_md058_violations.md
+++ b/test-samples/test_md058_violations.md
@@ -1,0 +1,77 @@
+# MD058 Test - Violations
+
+## Missing blank line above
+Text directly above table.
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+
+Text after table.
+
+## Missing blank line below
+
+Text before table.
+
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+Text directly below table.
+
+## Missing both blank lines above and below
+Text directly above.
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+Text directly below.
+
+## Multiple tables with missing spacing
+
+First text.
+
+| Table 1 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+Text between tables.
+| Table 2 | Header |
+| ------- | ------ |
+| Cell    | Value  |
+
+Final text.
+
+## Complex case with multiple violations
+
+Some initial text.
+| Table 1 | Missing | Above |
+| ------- | ------- | ----- |
+| Data    | Goes    | Here  |
+
+Middle text content.
+
+| Table 2 | Missing | Below |
+| ------- | ------- | ----- |
+| More    | Data    | Here  |
+Following text without spacing.
+
+## Table missing above spacing only
+
+Previous paragraph content.
+| Header | Value |
+| ------ | ----- |
+| Test   | Data  |
+
+Proper spacing below.
+
+## Table missing below spacing only
+
+Proper spacing above.
+
+| Header | Value |
+| ------ | ----- |
+| Test   | Data  |
+Immediate text below.
+
+## Single row table violations
+Text above.
+| Single Row |
+
+Text below.


### PR DESCRIPTION
Implements the MD058 rule that ensures tables are surrounded by blank lines for improved parser compatibility and document readability.

Key features:
- Detects missing blank lines above/below tables
- Handles edge cases (document start/end, empty content)
- Filters out tree-sitter parser quirks with pipe character validation
- Comprehensive test coverage with 10 unit tests
- Full parity validation against original markdownlint
- Complete documentation and test samples

Implementation details:
- Uses Token-based rule type for AST node analysis
- Validates actual table rows contain pipe characters
- Separate violation reporting for above/below spacing issues
- Proper handling of tables at document boundaries

Files added:
- Core implementation: crates/quickmark_linter/src/rules/md058.rs
- Documentation: docs/rules/md058.md
- Test samples: test-samples/test_md058_*.md
- Configuration: test-samples/quickmark-md058-only.toml

Updated README.md to reflect new rule (progress: 49/52 rules, 94.2% complete)

🤖 Generated with [Claude Code](https://claude.ai/code)