### PR TITLE
feat: implement hierarchical configuration discovery for LSP

### DIFF
--- a/crates/quickmark_linter/tests/fixtures/quickmark.toml
+++ b/crates/quickmark_linter/tests/fixtures/quickmark.toml
@@ -1,6 +1,0 @@
-[linters.severity]
-heading-increment = 'warn'
-heading-style = 'off'
-
-[linters.settings.heading-style]
-style = 'atx'

--- a/test-samples/hierarchical-test/README.md
+++ b/test-samples/hierarchical-test/README.md
@@ -1,0 +1,41 @@
+# Hierarchical Config Discovery Test Suite
+
+This directory contains integration tests for the hierarchical config discovery feature implemented for issue-43.
+
+## Directory Structure
+
+```
+hierarchical-test/
+├── project-root/                    # Main project with relaxed config
+│   ├── quickmark.toml              # MD001=off, MD013=warn(100 chars)
+│   ├── README.md                   # Uses project-root config
+│   ├── src/                        
+│   │   ├── quickmark.toml          # MD001=warn, MD013=err(80 chars)
+│   │   ├── api.md                  # Uses src/ config
+│   │   └── docs/
+│   │       └── guide.md            # Inherits src/ config
+│   └── tests/
+│       └── integration.md          # Inherits project-root config
+└── cargo-project/                  # Demonstrates Cargo.toml boundary
+    ├── Cargo.toml                  # Project root marker
+    ├── quickmark.toml              # setext_with_atx style
+    └── src/
+        └── lib.md                  # Uses cargo-project config
+```
+
+## Test Scenarios
+
+1. **Hierarchical Inheritance**: Files inherit the closest config in their ancestor directories
+2. **Different Configurations**: Each directory level can have different rule severities and settings
+3. **Project Boundaries**: Discovery stops at common project markers like `Cargo.toml`
+4. **Git Boundaries**: Discovery stops at `.git` directories to respect repository boundaries
+
+## Expected Behavior
+
+- `project-root/README.md`: MD001 disabled, 100-char line limit warnings
+- `project-root/src/api.md`: MD001 warnings, 80-char line limit errors  
+- `project-root/src/docs/guide.md`: Inherits src/ config (MD001 warnings, 80-char errors)
+- `project-root/tests/integration.md`: Inherits project-root config (MD001 disabled, 100-char warnings)
+- `cargo-project/src/lib.md`: Uses setext_with_atx style from cargo-project/quickmark.toml
+
+This demonstrates the full hierarchical config discovery working as specified in the LSP Phase 2 requirements.

--- a/test-samples/hierarchical-test/cargo-project/Cargo.toml
+++ b/test-samples/hierarchical-test/cargo-project/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test-project"
+version = "0.1.0"
+edition = "2021"

--- a/test-samples/hierarchical-test/cargo-project/quickmark.toml
+++ b/test-samples/hierarchical-test/cargo-project/quickmark.toml
@@ -1,0 +1,7 @@
+# Cargo project config - should stop discovery here
+[linters.severity]
+heading-increment = 'warn'
+heading-style = 'err'
+
+[linters.settings.heading-style]
+style = 'setext_with_atx'

--- a/test-samples/hierarchical-test/cargo-project/src/lib.md
+++ b/test-samples/hierarchical-test/cargo-project/src/lib.md
@@ -1,0 +1,10 @@
+# Library Documentation
+
+### Skip Level 2 (should trigger MD001 warning)
+
+Main Documentation
+==================
+
+## Sub Section
+
+This should be valid with setext_with_atx style.

--- a/test-samples/hierarchical-test/project-root/README.md
+++ b/test-samples/hierarchical-test/project-root/README.md
@@ -1,0 +1,10 @@
+# Project Root README
+
+### Skipped Level 2 Heading (should not trigger MD001 - disabled at project level)
+
+This line is intentionally very long to test the line length configuration at the project root level which allows 100 characters.
+
+Project Documentation
+====================
+
+This setext heading should trigger MD003 error because project config enforces ATX style.

--- a/test-samples/hierarchical-test/project-root/quickmark.toml
+++ b/test-samples/hierarchical-test/project-root/quickmark.toml
@@ -1,0 +1,11 @@
+# Project root config - should apply to all files in project
+[linters.severity]
+heading-increment = 'off'  # MD001 disabled at project level
+heading-style = 'err'       # MD003 enabled
+line-length = 'warn'        # MD013 as warning
+
+[linters.settings.heading-style]
+style = 'atx'
+
+[linters.settings.line-length]
+line_length = 100

--- a/test-samples/hierarchical-test/project-root/src/api.md
+++ b/test-samples/hierarchical-test/project-root/src/api.md
@@ -1,0 +1,10 @@
+# API Documentation
+
+### Skipped Level 2 (should trigger MD001 warning - enabled in src/)
+
+This line exceeds 80 characters and should trigger MD013 error in src/ directory configuration.
+
+API Reference
+=============
+
+This setext heading should trigger MD003 error.

--- a/test-samples/hierarchical-test/project-root/src/docs/guide.md
+++ b/test-samples/hierarchical-test/project-root/src/docs/guide.md
@@ -1,0 +1,10 @@
+# User Guide
+
+### Another skipped level heading (should trigger MD001 warning - inherited from src/)
+
+This line also exceeds the 80 character limit set in src/ config and should trigger error.
+
+Guide Section
+=============
+
+This setext heading should trigger MD003 error in docs/ subdirectory.

--- a/test-samples/hierarchical-test/project-root/src/quickmark.toml
+++ b/test-samples/hierarchical-test/project-root/src/quickmark.toml
@@ -1,0 +1,11 @@
+# Source code specific config - stricter for code documentation
+[linters.severity]
+heading-increment = 'warn'  # MD001 as warning for src/ 
+heading-style = 'err'       # MD003 still error
+line-length = 'err'         # MD013 stricter for code docs
+
+[linters.settings.heading-style]
+style = 'atx'
+
+[linters.settings.line-length]
+line_length = 80  # Shorter lines for code docs

--- a/test-samples/hierarchical-test/project-root/tests/integration.md
+++ b/test-samples/hierarchical-test/project-root/tests/integration.md
@@ -1,0 +1,10 @@
+# Integration Tests
+
+### Skip to level 3 (should not trigger MD001 - disabled at project root)
+
+This line is intentionally long but under 100 characters to test project root config - should be warning only.
+
+Test Documentation
+==================
+
+This setext heading should trigger MD003 error.


### PR DESCRIPTION
Add hierarchical configuration file discovery that searches upward from target file location, enabling proper LSP integration with project-specific configurations.

## Changes
- Enhanced config discovery in quickmark_linter/src/config/mod.rs with upward directory traversal
- Updated CLI and server applications to use hierarchical config discovery
- Added comprehensive test fixtures for hierarchical configuration scenarios
- Improved integration tests for CLI configuration handling
- Removed obsolete test fixture file

## Test Coverage
- Created hierarchical test scenarios with nested project structures
- Added Cargo project test case with workspace-level configuration
- Comprehensive integration tests ensuring proper config file precedence

This enables LSP servers to automatically discover the most appropriate configuration file for any given markdown file based on its location in the project hierarchy.

Fixes #43

🤖 Generated with [Claude Code](https://claude.ai/code)