### PR TITLE
chore: update quickmark-core dependency versions to 1.0.0-alpha.3

### DIFF
--- a/crates/quickmark-cli/Cargo.toml
+++ b/crates/quickmark-cli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 authors = ["Evgeny Kropotin"]
 repository = "https://github.com/ekropotin/quickmark"
 homepage = "https://github.com/ekropotin/quickmark"
-keywords = ["markdown", "linter", "commonmark", "lint", "cli"]
+keywords = ["markdown", "linter", "lint", "cli"]
 categories = ["command-line-utilities", "text-processing", "development-tools"]
 
 [[bin]]
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.1" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.3" }
 glob = "0.3"
 rayon = "1.8"
 ignore = "0.4"

--- a/crates/quickmark-server/Cargo.toml
+++ b/crates/quickmark-server/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing", "development-tools", "text-editors"]
 
 [dependencies]
 anyhow = "1.0.86"
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.1" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.3" }
 tower-lsp = "0.20.0"
 tokio = { version = "1.0", features = ["full"] }
 


### PR DESCRIPTION
Updates dependency versions in CLI and server crates to match the latest core version. Also removes 'commonmark' keyword from CLI crate to stay within keyword limits.

🤖 Generated with [Claude Code](https://claude.ai/code)