### PR TITLE
chore: update workflow configurations and track core changes

### DIFF
--- a/.github/workflows/crates-version-bump.yml
+++ b/.github/workflows/crates-version-bump.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       all:
-        description: 'Bump version for all crates (not just changed ones)'
+        description: 'Cascade version bump to downstream crates (crates, depending on the changed one)'
         required: false
-        default: false
+        default: true
         type: boolean
       pre-id:
         description: 'Prerelease identifier for prerelease versions'
@@ -14,7 +14,6 @@ on:
         default: 'alpha'
         type: choice
         options:
-          - alpha
           - beta
           - rc
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -133,10 +133,16 @@ jobs:
       - name: Organize binaries and changelog
         run: |
           mkdir -p release-binaries
-          find artifacts -name "quickmark-server-*" -type f -exec mv {} release-binaries/ \;
-          find artifacts -name "CHANGELOG.md" -type f -exec cp {} ./ \;
+          # Copy binaries from artifact subdirectories
+          for artifact_dir in artifacts/quickmark-server-*; do
+            if [ -d "$artifact_dir" ]; then
+              cp "$artifact_dir"/* release-binaries/
+            fi
+          done
+          # Copy changelog
+          cp artifacts/changelog/CHANGELOG.md ./ 2>/dev/null || echo "No changelog found"
           ls -la release-binaries/
-          ls -la CHANGELOG.md
+          if [ -f CHANGELOG.md ]; then ls -la CHANGELOG.md; fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- Update version bump workflow to cascade to downstream crates by default
- Remove alpha option from prerelease choices, keeping only beta and rc
- Fix release server workflow to properly organize binaries from artifacts
- Add proper error handling for missing changelog files
- Add .changed file to track quickmark-core modifications

🤖 Generated with [Claude Code](https://claude.ai/code)