### PR TITLE
chore: simplify version bump workflow and update dependencies

### DIFF
--- a/.github/workflows/crates-version-bump.yml
+++ b/.github/workflows/crates-version-bump.yml
@@ -3,11 +3,6 @@ name: Crates Version Bump
 on:
   workflow_dispatch:
     inputs:
-      all:
-        description: 'Cascade version bump to downstream crates (crates, depending on the changed one)'
-        required: false
-        default: true
-        type: boolean
       pre-id:
         description: 'Prerelease identifier for prerelease versions'
         required: false
@@ -53,25 +48,18 @@ jobs:
       - name: Run version bump
         run: |
           BRANCH="${GITHUB_REF_NAME}"
-          ALL_FLAG=""
           PRE_ID="${{ inputs.pre-id }}"
-
-          if [ "${{ inputs.all }}" = "true" ]; then
-            ALL_FLAG="--all"
-            echo "Will bump version for ALL crates"
-          else
-            echo "Will bump version for CHANGED crates only"
-          fi
 
           echo "Running on branch: $BRANCH"
           echo "Prerelease identifier: $PRE_ID"
+          echo "Will bump version for ALL crates"
 
           case "$BRANCH" in
             main)
-              cargo workspaces version --allow-branch "$BRANCH" --no-global-tag $ALL_FLAG --yes
+              cargo workspaces version --allow-branch "$BRANCH" --no-global-tag --yes
               ;;
             development)
-              cargo workspaces version --allow-branch "$BRANCH" --no-global-tag prerelease --pre-id "$PRE_ID" $ALL_FLAG --yes
+              cargo workspaces version --allow-branch "$BRANCH" --no-global-tag prerelease --pre-id "$PRE_ID" --yes
               ;;
             *)
               echo "❌ This workflow can only be run on 'main' or 'development'."

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ brew install quickmark-cli
 ##### Option 2 - from crates
 
 ```shell
-cargo install quickmark-cli --version 1.0.0-alpha.1
+cargo install quickmark-cli --version 1.0.0-beta.1
 ```
 
 ##### Option 3 - download from the release page
@@ -164,7 +164,7 @@ Or just drug and drop the file to the Extensions Pane in the editor.
 Install via cargo:
 
 ```bash
-cargo install quickmark-server --version 1.0.0-alpha.1
+cargo install quickmark-server --version 1.0.0-beta.1
 ```
 
 Or download the binary for your platform from the latest [release page](https://github.com/ekropotin/quickmark/releases)

--- a/crates/quickmark-cli/Cargo.toml
+++ b/crates/quickmark-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.3" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.1" }
 glob = "0.3"
 rayon = "1.8"
 ignore = "0.4"
@@ -25,7 +25,7 @@ walkdir = "2.4"
 
 [dev-dependencies.quickmark-core]
 path = "../quickmark-core"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 features = ["testing"]
 
 [dev-dependencies]

--- a/crates/quickmark-server/Cargo.toml
+++ b/crates/quickmark-server/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing", "development-tools", "text-editors"]
 
 [dependencies]
 anyhow = "1.0.86"
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-alpha.3" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.1" }
 tower-lsp = "0.20.0"
 tokio = { version = "1.0", features = ["full"] }
 


### PR DESCRIPTION
- Remove 'all' input parameter from crates-version-bump workflow
- Update quickmark-core dependency versions to 1.0.0-beta.1
- Update README installation instructions to use beta.1 version

🤖 Generated with [Claude Code](https://claude.ai/code)