### PR TITLE
fix: resolve binary naming collision in release workflow

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -58,19 +58,24 @@ jobs:
       - name: Build quickmark-server
         run: cargo build --release --bin quickmark-server --target ${{ matrix.target }}
 
-      - name: Prepare binary name
-        id: binary-name
+      - name: Prepare binary archive
+        id: binary-archive
         shell: bash
         run: |
-          BINARY_NAME="quickmark-server-${{ matrix.target }}${{ matrix.suffix }}"
-          echo "binary_name=$BINARY_NAME" >> $GITHUB_OUTPUT
-          echo "source_path=target/${{ matrix.target }}/release/quickmark-server${{ matrix.suffix }}" >> $GITHUB_OUTPUT
+          ARCHIVE_NAME="quickmark-server-${{ matrix.target }}.tar.gz"
+          echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
+          
+          # Create archive with the binary renamed to quickmark-server
+          mkdir -p archive-temp
+          cp "target/${{ matrix.target }}/release/quickmark-server${{ matrix.suffix }}" archive-temp/quickmark-server${{ matrix.suffix }}
+          tar -czf "$ARCHIVE_NAME" -C archive-temp quickmark-server${{ matrix.suffix }}
+          rm -rf archive-temp
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.binary-name.outputs.binary_name }}
-          path: ${{ steps.binary-name.outputs.source_path }}
+          name: ${{ steps.binary-archive.outputs.archive_name }}
+          path: ${{ steps.binary-archive.outputs.archive_name }}
           if-no-files-found: error
 
   publish:
@@ -130,24 +135,24 @@ jobs:
         with:
           path: artifacts
 
-      - name: Organize binaries and changelog
+      - name: Organize archives and changelog
         run: |
-          mkdir -p release-binaries
-          # Copy binaries from artifact subdirectories
+          mkdir -p release-archives
+          # Copy tar.gz archives from artifact subdirectories
           for artifact_dir in artifacts/quickmark-server-*; do
             if [ -d "$artifact_dir" ]; then
-              cp "$artifact_dir"/* release-binaries/
+              cp "$artifact_dir"/*.tar.gz release-archives/ 2>/dev/null || true
             fi
           done
           # Copy changelog
           cp artifacts/changelog/CHANGELOG.md ./ 2>/dev/null || echo "No changelog found"
-          ls -la release-binaries/
+          ls -la release-archives/
           if [ -f CHANGELOG.md ]; then ls -la CHANGELOG.md; fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: release-binaries/*
+          files: release-archives/*
           body_path: CHANGELOG.md
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![image](https://img.shields.io/badge/license-MIT-blue)](https://github.com/ekropotin/quickmark/blob/main/LICENSE)
 
-> **Notice:** This project is at super early stage of development. Expect frequent updates and breaking changes.
-
-An lightning-fast linter for Markdown/[CommonMark](https://commonmark.org/) files, written in Rust.
+Quickmark is a Markdown/[CommonMark](https://commonmark.org/) linter written in Rust with first-class LSP support, giving you fast, seamless feedback in any editor.
 
 QuickMark is not just another Markdown linter; it's a tool designed with the modern developer in mind. By prioritizing speed and integrating seamlessly with your development environment, QuickMark enhances your productivity and makes Markdown linting an effortless part of your workflow.
 
@@ -13,10 +11,16 @@ This project takes a lot of inspiration from David Anson's [markdownlint](https:
 - [CommonMark](https://spec.commonmark.org/current/)
 - [GitHub Flavored Markdown Spec](https://github.github.com/gfm/)
 
+## AI Disclaimer
+
+Quickmark is designed, architected, and primarily written by a human. AI tools (e.g., Claude) were used to speed up routine tasks — such as drafting documentation, refining commit messages, scaffolding GitHub Actions, or generating test boilerplate.
+
+All design decisions, core implementation, and linter logic are written and maintained by real people. Think of the AI as an assistant for the repetitive parts, not as the author of the project.
+
 ## Key features
 
 - ⚡️ **Rust-Powered Speed**: Leveraging the power of Rust, QuickMark offers exceptional performance, making linting operations swift and efficient, even for large Markdown files.
-- 🧵 **Parallel Processing**: Process multiple files simultaneously using Rust's parallel processing capabilities, dramatically reducing lint times for large projects.
+- 🧵 **Parallel Processing**: Process multiple files simultaneously, dramatically reducing lint times for large projects.
 - 🔎 **Smart File Discovery**: Automatically discover markdown files using glob patterns, directory traversal, and intelligent filtering.
 - ⚙️ **LSP Integration**: QuickMark integrates effortlessly with your favorite code editors through LSP, providing real-time feedback and linting suggestions directly within your editor.
 - 🧩 **Customizable Rules**: Tailor the linting rules to fit your project's specific needs, ensuring that your Markdown files adhere to your preferred style and standards.


### PR DESCRIPTION
Fixed the GitHub Actions release workflow where multiple platform binaries were overwriting each other due to identical artifact names. Now each platform creates a unique tar.gz archive (e.g., quickmark-server-aarch64-apple-darwin.tar.gz) containing the quickmark-server binary with proper platform-specific naming.

Changes:
- Create target-specific tar.gz archives instead of raw binaries
- Each archive contains quickmark-server binary (quickmark-server.exe for Windows)
- Updated release step to handle tar.gz archives
- Maintains original publish workflow structure

🤖 Generated with [Claude Code](https://claude.ai/code)