### PR TITLE
chore: update quickmark-core dependency to 1.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install quickmark-cli
 ##### Option 2 - from crates
 
 ```shell
-cargo install quickmark-cli --version 1.0.0-beta.1
+cargo install quickmark-cli --version 1.0.0-beta.2
 ```
 
 ##### Option 3 - download from the release page
@@ -171,7 +171,7 @@ Or just drug and drop the file to the Extensions Pane in the editor.
 Install via cargo:
 
 ```bash
-cargo install quickmark-server --version 1.0.0-beta.1
+cargo install quickmark-server --version 1.0.0-beta.2
 ```
 
 Or download the binary for your platform from the latest [release page](https://github.com/ekropotin/quickmark/releases)

--- a/crates/quickmark-cli/Cargo.toml
+++ b/crates/quickmark-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.1" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.2" }
 glob = "0.3"
 rayon = "1.8"
 ignore = "0.4"

--- a/crates/quickmark-server/Cargo.toml
+++ b/crates/quickmark-server/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing", "development-tools", "text-editors"]
 
 [dependencies]
 anyhow = "1.0.86"
-quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.1" }
+quickmark-core = { path = "../quickmark-core", version = "1.0.0-beta.2" }
 tower-lsp = "0.20.0"
 tokio = { version = "1.0", features = ["full"] }
 


### PR DESCRIPTION
Update dependency references in CLI and server crates to match the latest core library version.

🤖 Generated with [Claude Code](https://claude.ai/code)