### PR TITLE
ci: enhance release workflows with binary builds and improved structure

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -6,9 +6,61 @@ on:
       - 'quickmark-cli@*'
 
 jobs:
-  publish:
-    name: Publish to crates.io
+  build:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: qmark-x86_64-apple-darwin.tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: qmark-aarch64-apple-darwin.tar.gz
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Build binary
+        run: cargo build --release --bin qmark --target ${{ matrix.target }}
+
+      - name: Create archive
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/qmark dist/
+          cd dist && tar -czf ../${{ matrix.artifact }} qmark
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  release:
+    name: Create release
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: write
 
@@ -37,6 +89,12 @@ jobs:
         with:
           tool: cargo-release,git-cliff
 
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -51,5 +109,7 @@ jobs:
           body: ${{ steps.changelog.outputs.content }}
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          files: |
+            artifacts/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -6,8 +6,8 @@ on:
       - 'quickmark-core@*'
 
 jobs:
-  publish:
-    name: Publish to crates.io
+  release:
+    name: Create release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- Add binary build matrix for macOS (x86_64 and aarch64) in release-cli workflow
- Include built binaries as GitHub release assets
- Restructure workflows with separate build and release jobs
- Add artifact caching for better performance
- Rename workflow jobs for better clarity (publish -> build/release)

🤖 Generated with [Claude Code](https://claude.ai/code)