### PR TITLE
feat: refactor config discovery and severity handling

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+default: false
+
+MD051: true

--- a/README.md
+++ b/README.md
@@ -211,42 +211,48 @@ QuickMark uses a sophisticated hierarchical configuration discovery system that 
 
 #### Hierarchical Configuration Discovery
 
-QuickMark automatically discovers configuration files by searching upward from the target markdown file's directory, stopping at natural project boundaries. This enables different parts of your project to have their own linting rules while maintaining a sensible inheritance hierarchy.
+QuickMark automatically discovers configuration files by searching upward from the target markdown file's directory, stopping at repository boundaries. This enables different parts of your project to have their own linting rules while maintaining a sensible inheritance hierarchy.
 
 **Search Process:**
 
 - Starts from the directory containing the target markdown file
 - Searches upward through parent directories for `quickmark.toml` files
 - Uses the first configuration file found
-- Stops searching when it encounters project boundary markers
+- Stops searching when it encounters boundary markers
 
-**Project Boundary Markers** (search stops at these):
+**Boundary Markers** (search stops at these):
 
-- **IDE Workspace Roots**: Configured workspace directories (LSP integration)
+- **IDE Workspace Roots**: Configured workspace directories (LSP integration only)
 - **Git Repository Root**: Directories containing `.git`
-- **Common Project Markers**: `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `.vscode`, `.idea`, `.sublime-project`
+- **Current Working Directory**: For CLI usage (prevents searching beyond the directory where you ran the command)
 
 **Example Hierarchical Structure:**
 
 ```
 my-project/
+├── .git/                       # Git repository boundary (search stops here)
 ├── quickmark.toml              # Project-wide config (relaxed rules)
-├── Cargo.toml                  # Project boundary marker
+├── Cargo.toml                  # Regular project file (ignored during config search)
 ├── README.md                   # Uses project-wide config
 ├── src/
 │   ├── quickmark.toml          # Stricter rules for source code
 │   ├── api.md                  # Uses src/ config
 │   └── docs/
 │       └── guide.md            # Inherits src/ config (stricter)
-└── tests/
-    └── integration.md          # Uses project-wide config (relaxed)
+├── tests/
+│   └── integration.md          # Uses project-wide config (relaxed)
+└── vendor/
+    └── external-lib/
+        ├── .git/               # Another git boundary (search stops here)
+        └── README.md           # Uses default config (no inheritance from parent)
 ```
 
 In this example:
 
 - `src/api.md` and `src/docs/guide.md` use the stricter `src/quickmark.toml` configuration
-- `README.md` and `tests/integration.md` use the relaxed project-wide `quickmark.toml` configuration
-- Search stops at `Cargo.toml` level, preventing the search from going beyond the project boundary
+- `README.md` and `tests/integration.md` use the relaxed project-wide `quickmark.toml` configuration  
+- `vendor/external-lib/README.md` uses the default configuration because the search stops at the `.git` boundary
+- Only `.git` directories act as boundaries - other project markers like `Cargo.toml` are ignored
 
 #### Using QUICKMARK_CONFIG Environment Variable
 

--- a/crates/quickmark-cli/tests/cli_integration_tests.rs
+++ b/crates/quickmark-cli/tests/cli_integration_tests.rs
@@ -448,7 +448,7 @@ fn test_cli_hierarchical_config_discovery() {
 
 /// Test that config discovery stops at git repository boundaries
 #[test]
-fn test_cli_config_discovery_git_boundary() {
+fn test_cli_config_discovery_stops_at_git_boundary() {
     // Create a temporary git repository structure
     let temp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
Simplified config discovery which uses git and cwd boundaries only:

- Remove project markers (Cargo.toml, package.json, go.mod, etc.) as boundaries
- Keep only git repositories (.git) as meaningful boundaries for config search
- Add current working directory as boundary for CLI mode
- Update ConfigDiscovery struct to track current working directory
- Maintain workspace root boundaries for LSP integration
- Update README.md to reflect new simpler boundary detection strategy
- Remove obsolete test for Cargo.toml boundary detection
- Fix CLI integration test naming for consistency

Fix the bug, when the violations printed with WARN severity instead of ERR:

- The `print_cli_errors` function in `quickmark-cli` now directly uses the severity from the `RuleViolation` struct, instead of looking it up from the configuration. This simplifies the code and makes it more robust.
- The `MultiRuleLinter` in `quickmark-core` now injects the correct severity into each `RuleViolation` as it is created.
- The test for `print_cli_errors` has been updated to reflect these changes and now uses the `MultiRuleLinter` to generate violations with the correct severities. 🤖 Generated with [Claude Code](https://claude.ai/code)